### PR TITLE
fix Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
 script:
   - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("Bio"))`); Pkg.pin("Bio"); Pkg.resolve()'
   - julia -e 'using Bio; @assert isdefined(:Bio); @assert typeof(Bio) === Module'
-  - julia ~/.julia/Bio/test/runtests.jl
+  - julia test/runtests.jl


### PR DESCRIPTION
Fix travis integration - run tests using the script in the local directory rather than the installed Pkg directory.
