### PR TITLE
Require julia 0.3

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.2-
+julia 0.3-
 FactCheck


### PR DESCRIPTION
I don't think we should bother with 0.2 support, since 0.3 isn't far away.
