### PR TITLE
fit sequence printing to the window size

### DIFF
--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -222,7 +222,7 @@ function show{T}(io::IO, seq::NucleotideSequence{T})
 
     # don't show more than this many characters to avoid filling the screen
     # with junk
-    const maxcount = 50
+    const maxcount = Base.tty_size()[2] - 2
     if len > maxcount
         for nt in seq[1:div(maxcount, 2) - 1]
             write(io, convert(Char, nt))


### PR DESCRIPTION
Now a long sequence looks like:
![screen shot 2015-04-15 at 0 49 15](https://cloud.githubusercontent.com/assets/905683/7140931/520c60b4-e309-11e4-8e04-214f618a0c03.png)
