### PR TITLE
add the 'clipboard' methods for sequence types

### DIFF
--- a/src/seq/seq.jl
+++ b/src/seq/seq.jl
@@ -4,7 +4,7 @@ using Compat
 using Base.Intrinsics
 
 import Base: convert, getindex, show, length, start, next, done, copy, reverse,
-             show, endof, ==, isless
+             show, endof, ==, isless, clipboard
 
 export Nucleotide, DNANucleotide, RNANucleotide,
        DNA_A, DNA_C, DNA_G, DNA_T, DNA_N,
@@ -20,6 +20,7 @@ export Nucleotide, DNANucleotide, RNANucleotide,
 include("nucleotide.jl")
 include("aminoacid.jl")
 include("geneticcode.jl")
+include("util.jl")
 
 
 # TODO: pattern (pseudo-sequences with ambiguity codes, etc)

--- a/src/seq/util.jl
+++ b/src/seq/util.jl
@@ -1,0 +1,14 @@
+# Copy a whole sequence into the user's clipboard; it would be useful for
+# pasting a query sequence in web services like BLAST
+function clipboard(seq::Union(NucleotideSequence,AminoAcidSequence), width::Integer=50)
+    buf = IOBuffer()
+    for i in 1:length(seq)
+        if i % width == 1 && i > width
+            write(buf, '\n')
+        end
+        write(buf, convert(Char, seq[i]))
+    end
+    clipboard(bytestring(buf))
+end
+
+clipboard(x::Kmer) = clipboard(convert(String, x))


### PR DESCRIPTION
I believe this is cool:

1. Copy a sequence into your clipboard in REPL: `julia> genome[interval] |> clipboard`
2. Go to the BLAST/BLAT website and paste it in the web form.
3. Click a button.
4. Profit!