### PR TITLE
add parse method for amino acids

### DIFF
--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -81,7 +81,29 @@ function show(io::IO, aa::AminoAcid)
     end
 end
 
+const threeletter_to_aa = @compat Dict(
+    "ALA" => AA_A, "ARG" => AA_R, "ASN" => AA_N, "ASP" => AA_D, "CYS" => AA_C,
+    "GLN" => AA_Q, "GLU" => AA_E, "GLY" => AA_G, "HIS" => AA_H, "ILE" => AA_I,
+    "LEU" => AA_L, "LYS" => AA_K, "MET" => AA_M, "PHE" => AA_F, "PRO" => AA_P,
+    "SER" => AA_S, "THR" => AA_T, "TRP" => AA_W, "TYR" => AA_Y, "VAL" => AA_V,
+)
 
+function Base.parse(::Type{AminoAcid}, s::String)
+    s′ = strip(s)
+    if length(s′) == 1
+        return convert(AminoAcid, s′[1])
+    end
+    try
+        return threeletter_to_aa[uppercase(s′)]
+    catch ex
+        if isa(ex, KeyError)
+            error("invalid amino acid string: \"$s\"")
+        end
+        rethrow()
+    end
+end
+
+# TODO: tryparse
 
 # Amino Acids Sequences
 # =====================

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -89,7 +89,7 @@ const threeletter_to_aa = @compat Dict(
     "SER" => AA_S, "THR" => AA_T, "TRP" => AA_W, "TYR" => AA_Y, "VAL" => AA_V,
 )
 
-function Base.parse(::Type{AminoAcid}, s::String)
+function parse(::Type{AminoAcid}, s::String)
     s′ = strip(s)
     if length(s′) == 1
         return convert(AminoAcid, s′[1])

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -81,6 +81,7 @@ function show(io::IO, aa::AminoAcid)
     end
 end
 
+# lookup table of 20 standard amino acids
 const threeletter_to_aa = @compat Dict(
     "ALA" => AA_A, "ARG" => AA_R, "ASN" => AA_N, "ASP" => AA_D, "CYS" => AA_C,
     "GLN" => AA_Q, "GLU" => AA_E, "GLY" => AA_G, "HIS" => AA_H, "ILE" => AA_I,

--- a/src/seq/seq.jl
+++ b/src/seq/seq.jl
@@ -4,7 +4,7 @@ using Compat
 using Base.Intrinsics
 
 import Base: convert, getindex, show, length, start, next, done, copy, reverse,
-             show, endof, ==, isless, clipboard
+             show, endof, ==, isless, clipboard, parse
 
 export Nucleotide, DNANucleotide, RNANucleotide,
        DNA_A, DNA_C, DNA_G, DNA_T, DNA_N,

--- a/test/seq/test_seq.jl
+++ b/test/seq/test_seq.jl
@@ -1007,6 +1007,53 @@ facts("Aminoacids") do
             end
         end
     end
+
+    context("Parsers") do
+        context("Valid Cases") do
+            # case-insensitive and ignores spaces
+            @fact parse(AminoAcid, "a") => AA_A
+            @fact parse(AminoAcid, "Ala") => AA_A
+            @fact parse(AminoAcid, "aLa ") => AA_A
+            @fact parse(AminoAcid, " alA ") => AA_A
+            @fact parse(AminoAcid, "\tAlA\n") => AA_A
+            @fact parse(AminoAcid, "x") => AA_X
+            @fact parse(AminoAcid, "X") => AA_X
+            aas = [
+                ("A", "ALA", AA_A),
+                ("R", "ARG", AA_R),
+                ("N", "ASN", AA_N),
+                ("D", "ASP", AA_D),
+                ("C", "CYS", AA_C),
+                ("E", "GLU", AA_E),
+                ("Q", "GLN", AA_Q),
+                ("G", "GLY", AA_G),
+                ("H", "HIS", AA_H),
+                ("I", "ILE", AA_I),
+                ("L", "LEU", AA_L),
+                ("K", "LYS", AA_K),
+                ("M", "MET", AA_M),
+                ("F", "PHE", AA_F),
+                ("P", "PRO", AA_P),
+                ("S", "SER", AA_S),
+                ("T", "THR", AA_T),
+                ("W", "TRP", AA_W),
+                ("Y", "TYR", AA_Y),
+                ("V", "VAL", AA_V),
+            ]
+            @fact length(aas) => 20
+            for (one, three, aa) in aas
+                @fact parse(AminoAcid, one) => aa
+                @fact parse(AminoAcid, three) => aa
+            end
+        end
+
+        context("Invalid Cases") do
+            @fact_throws ErrorException parse(AminoAcid, "")
+            @fact_throws ErrorException parse(AminoAcid, "AL")
+            @fact_throws ErrorException parse(AminoAcid, "LA")
+            @fact_throws ErrorException parse(AminoAcid, "ALAA")
+        end
+    end
 end
 
 facts("Translation") do

--- a/test/seq/test_seq.jl
+++ b/test/seq/test_seq.jl
@@ -1048,10 +1048,10 @@ facts("Aminoacids") do
         end
 
         context("Invalid Cases") do
-            @fact_throws ErrorException parse(AminoAcid, "")
-            @fact_throws ErrorException parse(AminoAcid, "AL")
-            @fact_throws ErrorException parse(AminoAcid, "LA")
-            @fact_throws ErrorException parse(AminoAcid, "ALAA")
+            @fact_throws parse(AminoAcid, "")
+            @fact_throws parse(AminoAcid, "AL")
+            @fact_throws parse(AminoAcid, "LA")
+            @fact_throws parse(AminoAcid, "ALAA")
         end
     end
 end


### PR DESCRIPTION
We often use three-letter abbreviations to represent amino acids.
For example, Protein Data Bank (PDB) format adopts these three-letter encoding as its standard (http://www.wwpdb.org/documentation/file-format-content/format33/sect3.html#SEQRES).

This pull request implements a parser for one-letter and three-letter abbreviations which is case-insensitive and ignores white space.