### PR TITLE
Accession number types

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,3 +2,4 @@ julia 0.3-
 Compat
 Docile
 FactCheck
+URIParser

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -1,6 +1,6 @@
 module Bio
 
 include("seq/seq.jl")
-
+include("services/services.jl")
 
 end # module

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -6,14 +6,15 @@ export Accession, browse, uri
 using URIParser
 
 @doc """
-`Accession{S,T}` is a type holding an accession number of a database named as `S`,
-a symbol like `:RefSeq` or `:GeneOntology`. The accession number is encoded in a
-type `T`, but users don't have to care about `T` in most cases.
+`Accession{S,T}` is a type holding an accession number of a database named as
+`S`, a symbol like `:RefSeq` or `:GeneOntology`. The accession number is encoded
+in a type `T`, but users don't have to care about `T` in most cases.
 
-To make an `Accession` object from a string, you can call `parse(Accession{S}, str)`.
-For example, `parse(Accession{:RefSeq}, "NC_000017.11")` creates an accession object
-of the NCBI RefSeq database. But in this case, `parse(Accession, "NC_000017.11")`
-or even more compactly `Accession("NC_000017.11")` works well because the accession
+To make an `Accession` object from a string, you can call
+`parse(Accession{S}, str)`.  For example,
+`parse(Accession{:RefSeq}, "NC_000017.11")` creates an accession object of the
+NCBI RefSeq database. But in this case, `parse(Accession, "NC_000017.11")` or
+even more compactly `Accession("NC_000017.11")` works well because the accession
 string has a distinctive prefix "NC_" and its accession type can be nicely inferred.
 """ ->
 immutable Accession{S,T}
@@ -58,10 +59,11 @@ const parse_trial_order = [
 ]
 
 @doc """
-Parse an accession string smartly. If the accession string has a distinctive pattern
-like a unique prefix, this function will be able to guess the type of the accession
-number; otherwise it will fail to parse and raise an error. Since the guessing method
-is not so reliable, the result should be checked by a caller.
+Parse an accession string smartly. If the accession string has a distinctive
+pattern like a unique prefix, this function will be able to guess the type of
+the accession number; otherwise it will fail to parse and raise an error.
+Since the guessing method is not so reliable, the result should be checked by
+a caller.
 """ ->
 function parse(::Type{Accession}, s::String)
     for name in parse_trial_order
@@ -147,7 +149,7 @@ function ismatch(::Type{Accession{:EntrezGene}}, s::String)
 end
 
 @doc """
-Parse an accession number string of Entrez Gene (e.g. "7157" for TP53 gene of H.sapiens).
+Parse an accession number string of Entrez Gene (e.g. "7157").
 """ ->
 function parse(::Type{Accession{:EntrezGene}}, s::String)
     @check_match :EntrezGene s
@@ -208,7 +210,7 @@ function ismatch(::Type{Accession{:GenBank}}, s::String)
 end
 
 @doc """
-Parse an accession number of GenBank (e.g. "AB082923.1" for H.sapiens mRNA for P53).
+Parse an accession number of GenBank (e.g. "AB082923.1").
 """ ->
 function parse(::Type{Accession{:GenBank}}, s::String)
     @check_match :GenBank s
@@ -256,7 +258,7 @@ function ismatch(::Type{Accession{:RefSeq}}, s::String)
 end
 
 @doc """
-Parse an accession number string of NCBI RefSeq (e.g. "NC_000017.11" for a genomic assembly).
+Parse an accession number string of NCBI RefSeq (e.g. "NC_000017.11").
 """ ->
 function parse(::Type{Accession{:RefSeq}}, s::String)
     @check_match :RefSeq s
@@ -426,7 +428,10 @@ end
 #   http://www.uniprot.org/help/accession_numbers
 
 function ismatch(::Type{Accession{:UniProt}}, s::String)
-    return ismatch(r"^\s*(:?[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](:?[A-Z][A-Z0-9]{2}[0-9]){1,2})\s*$", s)
+    return ismatch(
+        r"^\s*(:?[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9](:?[A-Z][A-Z0-9]{2}[0-9]){1,2})\s*$",
+        s
+    )
 end
 
 @doc """

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -1,4 +1,6 @@
-export Accession, browse
+export Accession, browse, uri
+
+using URIParser
 
 # Accession numbers (S::Symbol database name, T::DataType encoding type)
 immutable Accession{S,T}
@@ -16,6 +18,10 @@ end
 =={S}(x::Accession{S}, y::String) = x == parse(Accession{S}, y)
 =={S}(x::String, y::Accession{S}) = parse(Accession{S}, x) == y
 hash(x::Accession) = hash(x.data)
+
+function browse(accession::Accession)
+    run(`open $(uri(accession, format=:browser))`)
+end
 
 # Smart Accession Parser
 #
@@ -282,6 +288,8 @@ end
 
 # Gene Ontology
 
+# http://geneontology.org/page/ontology-structure#termstru
+
 function ismatch(::Type{Accession{:GeneOntology}}, s::String)
     return ismatch(r"^\s*GO:\d{7}\s*$", s)
 end
@@ -325,4 +333,14 @@ end
 function show(io::IO, uniprot::Accession{:UniProt})
     write(io, uniprot.data)
     return
+end
+
+function uri(uniprot::Accession{:UniProt}; format::Symbol=:browser)
+    if format === :browser
+        ext = ""
+    else
+        @assert format ∈ [:txt, :fasta, :xml, :rdf, :gff]
+        ext = "." * string(format)
+    end
+    return URI("http://www.uniprot.org/uniprot/$uniprot$ext")
 end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -1,0 +1,136 @@
+export Accession, EntrezGene, GenBank, RefSeq, GOTerm, browse
+
+
+immutable Accession{T}
+    data::T
+end
+
+=={T}(x::Accession{T}, y::Accession{T}) = x.data == y.data
+=={T}(x::Accession{T}, y::String) = x.data == parse(T, y)
+=={T}(x::String, y::Accession{T}) = parse(T, x) == y.data
+
+parse{T}(::Type{Accession{T}}, x::String) = Accession(parse(T, x))
+show(io::IO, x::Accession) = show(io, x.data)
+browse(x::Accession) = browse(x.data)
+
+
+# Entrez Gene
+
+bitstype 32 EntrezGene
+
+convert(::Type{EntrezGene}, geneid::Uint32) = box(EntrezGene, unbox(Uint32, geneid))
+convert(::Type{Uint32}, geneid::EntrezGene) = box(Uint32, unbox(EntrezGene, geneid))
+
+parse(::Type{EntrezGene}, s::String) = convert(EntrezGene, parse(Uint32, s))
+
+function show(io::IO, geneid::EntrezGene)
+    @printf io "%d" convert(Uint32, geneid)
+end
+
+@osx_only function browse(geneid::EntrezGene)
+    run(`open http://www.ncbi.nlm.nih.gov/gene/?term=$geneid`)
+end
+
+
+# GenBank
+
+immutable GenBank
+    accession::ASCIIString
+    version::Uint8
+end
+
+==(x::GenBank, y::GenBank) = x.accession == y.accession && x.version == y.version
+
+function parse(::Type{GenBank}, s::String)
+    s = strip(s)
+    dot = search(s, '.')
+    @assert dot > 0
+    acc = s[1:dot-1]
+    version = parse(Uint8, s[dot+1:end])
+    return GenBank(acc, version)
+end
+
+function show(io::IO, genbank::GenBank)
+    print(io, genbank.accession)
+    print(io, '.')
+    print(io, genbank.version)
+end
+
+@osx_only function browse(genbank::GenBank)
+    run(`open http://www.ncbi.nlm.nih.gov/nuccore/$genbank`)
+end
+
+# RefSeq
+
+immutable RefSeq
+    prefix::Uint8
+    number::Uint32
+    version::Uint8
+end
+
+# generate lookup table 
+macro gen_table(name, typ, xs)
+    xs = eval(xs)
+    enc_table = symbol(string(name, :_encode))
+    dec_table = symbol(string(name, :_decode))
+    esc(quote
+        const $enc_table = [x => convert($typ, i) for (i, x) in enumerate($xs)]
+        const $dec_table = $xs
+    end)
+end
+
+# http://www.ncbi.nlm.nih.gov/books/NBK21091/ (Table 1)
+@gen_table refseq_prefix Uint8 [
+    "AC_", "NC_", "NG_", "NT_", "NW_",
+    "NS_", "NZ_", "NM_", "NR_", "XM_",
+    "XR_", "AP_", "NP_", "YP_", "XP_",
+    "ZP_",
+]
+
+function parse(::Type{RefSeq}, s::String)
+    s = strip(s)
+    prefix = refseq_prefix_encode[s[1:3]]
+    dot = search(s, '.')
+    @assert dot > 0
+    number = parse(Uint32, s[4:dot-1])
+    version = parse(Uint8, s[dot+1:end])
+    return RefSeq(prefix, number, version)
+end
+
+function show(io::IO, refseq::RefSeq)
+    prefix = refseq_prefix_decode[refseq.prefix]
+    nd = ndigits(refseq.number)
+    if nd <= 6
+        @printf io "%s%06d.%d" prefix refseq.number refseq.version
+    elseif nd <= 9
+        @printf io "%s%09d.%d" prefix refseq.number refseq.version
+    else
+        error("overflow")
+    end
+end
+
+@osx_only function browse(refseq::RefSeq)
+    run(`open http://www.ncbi.nlm.nih.gov/nuccore/$refseq`)
+end
+
+
+# Gene Ontology
+
+bitstype 32 GOTerm
+
+convert(::Type{GOTerm}, goterm::Uint32) = box(GOTerm, unbox(Uint32, goterm))
+convert(::Type{Uint32}, goterm::GOTerm) = box(Uint32, unbox(GOTerm, goterm))
+
+function parse(::Type{GOTerm}, s::String)
+    s = strip(s)
+    @assert startswith(s, "GO:")
+    convert(GOTerm, parse(Uint32, s[4:end]))
+end
+
+function show(io::IO, goterm::GOTerm)
+    @printf io "GO:%07d" convert(Uint32, goterm)
+end
+
+@osx_only function browse(goterm::GOTerm)
+    run(`open http://amigo.geneontology.org/amigo/term/$goterm`)
+end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -8,6 +8,7 @@ end
 =={T}(x::Accession{T}, y::Accession{T}) = x.data == y.data
 =={T}(x::Accession{T}, y::String) = x.data == parse(T, y)
 =={T}(x::String, y::Accession{T}) = parse(T, x) == y.data
+hash(x::Accession) = hash(x.data)
 
 parse{T}(::Type{Accession{T}}, x::String) = Accession(parse(T, x))
 show(io::IO, x::Accession) = show(io, x.data)
@@ -26,6 +27,8 @@ parse(::Type{EntrezGene}, s::String) = convert(EntrezGene, parse(Uint32, s))
 function show(io::IO, geneid::EntrezGene)
     @printf io "%d" convert(Uint32, geneid)
 end
+
+hash(geneid::EntrezGene) = hash(convert(Uint32, geneid))
 
 @osx_only function browse(geneid::EntrezGene)
     run(`open http://www.ncbi.nlm.nih.gov/gene/?term=$geneid`)
@@ -56,6 +59,8 @@ function show(io::IO, genbank::GenBank)
     print(io, genbank.version)
 end
 
+hash(genbank::GenBank) = hash(genbank.accession) $ hash(genbank.version)
+
 @osx_only function browse(genbank::GenBank)
     run(`open http://www.ncbi.nlm.nih.gov/nuccore/$genbank`)
 end
@@ -68,7 +73,7 @@ immutable RefSeq
     version::Uint8
 end
 
-# generate lookup table 
+# generate lookup table
 macro gen_table(name, typ, xs)
     xs = eval(xs)
     enc_table = symbol(string(name, :_encode))
@@ -109,6 +114,8 @@ function show(io::IO, refseq::RefSeq)
     end
 end
 
+hash(refseq::RefSeq) = hash(refseq.prefix) $ hash(refseq.number) $ hash(refseq.version)
+
 @osx_only function browse(refseq::RefSeq)
     run(`open http://www.ncbi.nlm.nih.gov/nuccore/$refseq`)
 end
@@ -130,6 +137,8 @@ end
 function show(io::IO, goterm::GOTerm)
     @printf io "GO:%07d" convert(Uint32, goterm)
 end
+
+hash(goterm::GOTerm) = hash(convert(Uint32, goterm))
 
 @osx_only function browse(goterm::GOTerm)
     run(`open http://amigo.geneontology.org/amigo/term/$goterm`)

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -20,7 +20,17 @@ end
 hash(x::Accession) = hash(x.data)
 
 function browse(accession::Accession)
-    run(`open $(uri(accession, format=:browser))`)
+    link = uri(accession, format=:browser)
+    # copied from Gadfly.jl
+    if OS_NAME == :Darwin
+        run(`open $link`)
+    elseif OS_NAME == :Linux || OS_NAME == :FreeBSD
+        run(`xdg-open $link`)
+    elseif OS_NAME == :Windows
+        run(`$(ENV["COMSPEC"]) /c start $link`)
+    else
+        warn("Opening a web browser is not supported on OS $(string(OS_NAME))")
+    end
 end
 
 # Smart Accession Parser
@@ -203,7 +213,7 @@ end
 
 hash(refseq::RefSeq) = hash(refseq.prefix) $ hash(refseq.number) $ hash(refseq.version)
 
-function uri(refseq::Accession{:RefSeq}; browser::Symbol=:browser)
+function uri(refseq::Accession{:RefSeq}; format::Symbol=:browser)
     @assert format === :browser
     return URI("http://www.ncbi.nlm.nih.gov/nuccore/$refseq")
 end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -81,8 +81,9 @@ function show(io::IO, geneid::Accession{:EntrezGene})
     @printf io "%d" convert(Uint32, geneid.data)
 end
 
-@osx_only function browse(geneid::Accession{:EntrezGene})
-    run(`open http://www.ncbi.nlm.nih.gov/gene/?term=$geneid`)
+function uri(geneid::Accession{:EntrezGene}; format::Symbol=:browser)
+    @assert format === :browser
+    return URI("http://www.ncbi.nlm.nih.gov/gene/?term=$geneid")
 end
 
 
@@ -127,8 +128,9 @@ end
 
 hash(genbank::GenBank) = hash(genbank.accession) $ hash(genbank.version)
 
-@osx_only function browse(genbank::Accession{:GenBank})
-    run(`open http://www.ncbi.nlm.nih.gov/nuccore/$genbank`)
+function uri(genbank::Accession{:GenBank}; format::Symbol=:browser)
+    @assert format === :browser
+    return URI("http://www.ncbi.nlm.nih.gov/nuccore/$genbank")
 end
 
 
@@ -201,8 +203,9 @@ end
 
 hash(refseq::RefSeq) = hash(refseq.prefix) $ hash(refseq.number) $ hash(refseq.version)
 
-@osx_only function browse(refseq::Accession{:RefSeq})
-    run(`open http://www.ncbi.nlm.nih.gov/nuccore/$refseq`)
+function uri(refseq::Accession{:RefSeq}; browser::Symbol=:browser)
+    @assert format === :browser
+    return URI("http://www.ncbi.nlm.nih.gov/nuccore/$refseq")
 end
 
 # Consensus CDS (CCDS)
@@ -239,6 +242,11 @@ function show(io::IO, ccds::Accession{:CCDS})
     if ccds.data.version > 0
         @printf io ".%d" ccds.data.version
     end
+end
+
+function uri(ccds::Accession{:CCDS}; format::Symbol=:browser)
+    @assert format === :browser
+    return URI("http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi?REQUEST=CCDS&DATA=$ccds")
 end
 
 
@@ -285,6 +293,10 @@ function show(io::IO, ensembl::Accession{:Ensembl})
     end
 end
 
+# TODO: permanent link to an entry
+#function uri(ensembl::Accession{:Ensembl}; format::Symbol=:browser)
+#end
+
 
 # Gene Ontology
 
@@ -308,8 +320,15 @@ function show(io::IO, go::Accession{:GeneOntology})
     @printf io "GO:%07d" convert(Uint32, go.data)
 end
 
-@osx_only function browse(go::Accession{:GeneOntology})
-    run(`open http://amigo.geneontology.org/amigo/term/$go`)
+function uri(go::Accession{:GeneOntology}; format::Symbol=:browser)
+    if format === :browser
+        q = "id=$go"
+    else
+        @assert format ∈ [:mini, :obo, :oboxml]
+        q = "id=$go&format=$format"
+    end
+    # TODO: AmiGO or QuickGO
+    return URI("http://www.ebi.ac.uk/QuickGO/GTerm?$q")
 end
 
 
@@ -340,7 +359,7 @@ function uri(uniprot::Accession{:UniProt}; format::Symbol=:browser)
         ext = ""
     else
         @assert format ∈ [:txt, :fasta, :xml, :rdf, :gff]
-        ext = "." * string(format)
+        ext = ".$format"
     end
     return URI("http://www.uniprot.org/uniprot/$uniprot$ext")
 end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -17,7 +17,11 @@ end
 =={S}(x::String, y::Accession{S}) = parse(Accession{S}, x) == y
 hash(x::Accession) = hash(x.data)
 
-# smart parser (should not be used outside of an interactive session)
+# Smart Accession Parser
+#
+# This function should not be used outside of an interactive session because
+# the strategy of guessing accession types is ad hoc and the results should be
+# checked by callers: the inferred types may not be what you thought!
 function parse(::Type{Accession}, s::String)
     if ismatch(Accession{:RefSeq}, s)
         return parse(Accession{:RefSeq}, s)
@@ -53,14 +57,12 @@ function parse_decimal_uint(s::String, start::Int=1, stop::Int=endof(s))
 end
 
 function search_nonspace(s::String)
-    i = 1
-    while isspace(s[i])
-        i += 1
-        if i > endof(s)
-            return 0
+    for i in 1:endof(s)
+        if !isspace(s[i])
+            return i
         end
     end
-    return i
+    return 0
 end
 
 
@@ -84,6 +86,8 @@ end
 
 
 # GenBank
+
+# http://www.ncbi.nlm.nih.gov/Sequin/acc.html
 
 immutable GenBank
     accession::ASCIIString
@@ -215,7 +219,7 @@ function parse(::Type{Accession{:GeneOntology}}, s::String)
         error("invalid GeneOntology accession number")
     end
     i = search_nonspace(s)
-    # `+ 3` is an offset of the prefix 'GO:'
+    # `+ 3` is the offset of the prefix 'GO:'
     n = parse_decimal_uint(s, i + 3)
     return Accession{:GeneOntology,Uint32}(n)
 end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -159,6 +159,29 @@ function uri(geneid::Accession{:EntrezGene}; format::Symbol=:browser)
 end
 
 
+# GenInfo Identifier (GI)
+# -----------------------
+
+# accession format:
+#   http://www.ncbi.nlm.nih.gov/genbank/sequenceids/
+
+function ismatch(::Type{Accession{:GI}}, s::String)
+    return ismatch(r"^\s*[1-9]\d*\s*$", s)
+end
+
+function parse(::Type{Accession{:GI}}, s::String)
+    @check_match :GI s
+    return Accession{:GI,Uint}(parse(Uint, s))
+end
+
+show(io::IO, gi::Accession{:GI}) = print(io, gi.data)
+
+function uri(gi::Accession{:GI}; format::Symbol=:browser)
+    @assert format === :browser
+    return URI("http://www.ncbi.nlm.nih.gov/nuccore/$gi")
+end
+
+
 # GenBank 
 # -------
 
@@ -209,6 +232,7 @@ end
 #   http://www.ncbi.nlm.nih.gov/refseq/
 # accession format:
 #   http://www.ncbi.nlm.nih.gov/books/NBK21091/
+#   http://www.ncbi.nlm.nih.gov/genbank/sequenceids/
 
 function ismatch(::Type{Accession{:RefSeq}}, s::String)
     return ismatch(r"^\s*(:?A[CP]|N[CGTWSZMRP]|X[MRP]|YP|ZP)_[A-Z0-9]+(:?\.\d+)?\s*$", s)

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -1,36 +1,76 @@
-export Accession, EntrezGene, GenBank, RefSeq, GOTerm, browse
+export Accession, browse
 
-
-immutable Accession{T}
+# Accession numbers (S::Symbol database name, T::DataType encoding type)
+immutable Accession{S,T}
+    # encoded accession number
     data::T
 end
 
-=={T}(x::Accession{T}, y::Accession{T}) = x.data == y.data
-=={T}(x::Accession{T}, y::String) = x.data == parse(T, y)
-=={T}(x::String, y::Accession{T}) = parse(T, x) == y.data
+Accession(s::String) = parse(Accession, s)
+
+if VERSION >= v"v0.4-"
+    Base.call{S}(::Type{Accession{S}}, s::String) = parse(Accession{S}, s)
+end
+
+=={S,T}(x::Accession{S,T}, y::Accession{S,T}) = x.data == y.data
+=={S}(x::Accession{S}, y::String) = x == parse(Accession{S}, y)
+=={S}(x::String, y::Accession{S}) = parse(Accession{S}, x) == y
 hash(x::Accession) = hash(x.data)
 
-parse{T}(::Type{Accession{T}}, x::String) = Accession(parse(T, x))
-show(io::IO, x::Accession) = show(io, x.data)
-browse(x::Accession) = browse(x.data)
+# smart parser (should not be used outside of an interactive session)
+function parse(::Type{Accession}, s::String)
+    if ismatch(Accession{:RefSeq}, s)
+        return parse(Accession{:RefSeq}, s)
+    elseif ismatch(Accession{:CCDS}, s)
+        return parse(Accession{:CCDS}, s)
+    elseif ismatch(Accession{:Ensembl}, s)
+        return parse(Accession{:Ensembl}, s)
+    elseif ismatch(Accession{:GeneOntology}, s)
+        return parse(Accession{:GeneOntology}, s)
+    end
+    error("cannot guess accession number type")
+end
+
+# parser of decimal integer; this is very common among accession numbers
+function parse_decimal_int(s::String, start::Int=1, stop::Int=endof(s))
+    # TODO overflow handling
+    @assert 1 <= start <= stop <= endof(s)
+    n = 0
+    i = start
+    while i <= stop
+        c = s[i]
+        if '0' <= c <= '9'
+            n = 10n + (c - '0')
+        elseif isspace(c)
+            break
+        else
+            error("invalid character: '$c'")
+        end
+        i += 1
+    end
+    return n
+end
+
+function search_nonspace(s::String)
+    i = 1
+    while isspace(s[i])
+        i += 1
+    end
+    return i
+end
 
 
 # Entrez Gene
 
-bitstype 32 EntrezGene
-
-convert(::Type{EntrezGene}, geneid::Uint32) = box(EntrezGene, unbox(Uint32, geneid))
-convert(::Type{Uint32}, geneid::EntrezGene) = box(Uint32, unbox(EntrezGene, geneid))
-
-parse(::Type{EntrezGene}, s::String) = convert(EntrezGene, parse(Uint32, s))
-
-function show(io::IO, geneid::EntrezGene)
-    @printf io "%d" convert(Uint32, geneid)
+function parse(::Type{Accession{:EntrezGene}}, s::String)
+    return Accession{:EntrezGene,Uint32}(parse_decimal_int(s, search_nonspace(s)))
 end
 
-hash(geneid::EntrezGene) = hash(convert(Uint32, geneid))
+function show(io::IO, geneid::Accession{:EntrezGene})
+    @printf io "%d" convert(Uint32, geneid.data)
+end
 
-@osx_only function browse(geneid::EntrezGene)
+@osx_only function browse(geneid::Accession{:EntrezGene})
     run(`open http://www.ncbi.nlm.nih.gov/gene/?term=$geneid`)
 end
 
@@ -42,28 +82,29 @@ immutable GenBank
     version::Uint8
 end
 
-==(x::GenBank, y::GenBank) = x.accession == y.accession && x.version == y.version
+==(x::GenBank, y::GenBank) = x.version == y.version && x.accession == y.accession
 
-function parse(::Type{GenBank}, s::String)
+function parse(::Type{Accession{:GenBank}}, s::String)
     s = strip(s)
     dot = search(s, '.')
     @assert dot > 0
-    acc = s[1:dot-1]
+    accession = s[1:dot-1]
     version = parse(Uint8, s[dot+1:end])
-    return GenBank(acc, version)
+    return Accession{:GenBank,GenBank}(GenBank(accession, version))
 end
 
-function show(io::IO, genbank::GenBank)
-    print(io, genbank.accession)
+function show(io::IO, genbank::Accession{:GenBank})
+    print(io, genbank.data.accession)
     print(io, '.')
-    print(io, genbank.version)
+    print(io, genbank.data.version)
 end
 
 hash(genbank::GenBank) = hash(genbank.accession) $ hash(genbank.version)
 
-@osx_only function browse(genbank::GenBank)
+@osx_only function browse(genbank::Accession{:GenBank})
     run(`open http://www.ncbi.nlm.nih.gov/nuccore/$genbank`)
 end
+
 
 # RefSeq
 
@@ -92,54 +133,85 @@ end
     "ZP_",
 ]
 
-function parse(::Type{RefSeq}, s::String)
+function ismatch(::Type{Accession{:RefSeq}}, s::String)
+    ismatch(r"^\s*(:?A[CP]|N[CGTWSZMRP]|X[MRP]|YP|ZP)_\d{6}(:?\d{3})?\.\d+\s*$", s)
+    #             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~   ^~
+    #             prefix                              number            version
+end
+
+function parse(::Type{Accession{:RefSeq}}, s::String)
     s = strip(s)
     prefix = refseq_prefix_encode[s[1:3]]
     dot = search(s, '.')
     @assert dot > 0
     number = parse(Uint32, s[4:dot-1])
     version = parse(Uint8, s[dot+1:end])
-    return RefSeq(prefix, number, version)
+    return Accession{:RefSeq,RefSeq}(RefSeq(prefix, number, version))
 end
 
-function show(io::IO, refseq::RefSeq)
-    prefix = refseq_prefix_decode[refseq.prefix]
-    nd = ndigits(refseq.number)
+function show(io::IO, refseq::Accession{:RefSeq})
+    prefix = refseq_prefix_decode[refseq.data.prefix]
+    nd = ndigits(refseq.data.number)
     if nd <= 6
-        @printf io "%s%06d.%d" prefix refseq.number refseq.version
+        @printf io "%s%06d.%d" prefix refseq.data.number refseq.data.version
     elseif nd <= 9
-        @printf io "%s%09d.%d" prefix refseq.number refseq.version
+        @printf io "%s%09d.%d" prefix refseq.data.number refseq.data.version
     else
-        error("overflow")
+        error("number overflow")
     end
 end
 
 hash(refseq::RefSeq) = hash(refseq.prefix) $ hash(refseq.number) $ hash(refseq.version)
 
-@osx_only function browse(refseq::RefSeq)
+@osx_only function browse(refseq::Accession{:RefSeq})
     run(`open http://www.ncbi.nlm.nih.gov/nuccore/$refseq`)
+end
+
+# Consensus CDS (CCDS)
+
+# http://www.ncbi.nlm.nih.gov/CCDS/CcdsBrowse.cgi#ccdsIds
+
+immutable CCDS
+    number::Uint32
+    version::Uint8
+end
+
+function ismatch(::Type{Accession{:CCDS}}, s::String)
+    return ismatch(r"^\s*CCDS\d+\.\d+\s*$", s)
+end
+
+
+# Ensembl
+
+# http://www.ensembl.org/info/genome/stable_ids/index.html
+
+function ismatch(::Type{Accession{:Ensembl}}, s::String)
+    return ismatch(r"^\s*(:?ENS(:?[A-Z]{3,4}?)|FB)(:?E|FM|G|GT|P|R|T)\d+\s*$", s)
+    #                    ^~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~^~~
+    #                    species prefix           feature prefix     number
+end
+
+function parse(::Type{Accession{:Ensembl,ASCIIString}}, s::String)
+    return Accession{:Ensembl,ASCIIString}(strip(s))
 end
 
 
 # Gene Ontology
 
-bitstype 32 GOTerm
+function ismatch(::Type{Accession{:GeneOntology}}, s::String)
+    ismatch(r"^\s*GO:\d{7}\s*$", s)
+end
 
-convert(::Type{GOTerm}, goterm::Uint32) = box(GOTerm, unbox(Uint32, goterm))
-convert(::Type{Uint32}, goterm::GOTerm) = box(Uint32, unbox(GOTerm, goterm))
-
-function parse(::Type{GOTerm}, s::String)
+function parse(::Type{Accession{:GeneOntology}}, s::String)
     s = strip(s)
     @assert startswith(s, "GO:")
-    convert(GOTerm, parse(Uint32, s[4:end]))
+    return Accession{:GeneOntology,Uint32}(parse(Uint32, s[4:end]))
 end
 
-function show(io::IO, goterm::GOTerm)
-    @printf io "GO:%07d" convert(Uint32, goterm)
+function show(io::IO, go::Accession{:GeneOntology})
+    @printf io "GO:%07d" convert(Uint32, go.data)
 end
 
-hash(goterm::GOTerm) = hash(convert(Uint32, goterm))
-
-@osx_only function browse(goterm::GOTerm)
-    run(`open http://amigo.geneontology.org/amigo/term/$goterm`)
+@osx_only function browse(go::Accession{:GeneOntology})
+    run(`open http://amigo.geneontology.org/amigo/term/$go`)
 end

--- a/src/services/accession.jl
+++ b/src/services/accession.jl
@@ -31,6 +31,8 @@ function parse(::Type{Accession}, s::String)
         return parse(Accession{:Ensembl}, s)
     elseif ismatch(Accession{:GeneOntology}, s)
         return parse(Accession{:GeneOntology}, s)
+    elseif ismatch(Accession{:UniProt}, s)
+        return parse(Accession{:UniProt}, s)
     end
     error("cannot guess accession number type")
 end
@@ -300,4 +302,27 @@ end
 
 @osx_only function browse(go::Accession{:GeneOntology})
     run(`open http://amigo.geneontology.org/amigo/term/$go`)
+end
+
+
+# UniProt
+
+# http://www.uniprot.org/help/accession_numbers
+
+function ismatch(::Type{Accession{:UniProt}}, s::String)
+    return ismatch(r"^\s*(:?[OPQ][0-9][A-Z0-9]{3}[0-9]|[A-NR-Z][0-9]([A-Z][A-Z0-9]{2}[0-9]){1,2})\s*$", s)
+end
+
+function parse(::Type{Accession{:UniProt}}, s::String)
+    if !ismatch(Accession{:UniProt}, s)
+        error("invalid UniProt accession number")
+    end
+    i = findfirst_nonspace(s)
+    j = findnext(c -> isspace(c), s, i)
+    return Accession{:UniProt,ASCIIString}(s[i:(j == 0 ? endof(s) : j - 1)])
+end
+
+function show(io::IO, uniprot::Accession{:UniProt})
+    write(io, uniprot.data)
+    return
 end

--- a/src/services/services.jl
+++ b/src/services/services.jl
@@ -2,7 +2,7 @@ module Services
 
 using Compat
 
-import Base: convert, parse, box, unbox, ==, show, hash
+import Base: parse, ==, show, hash, ismatch
 
 include("accession.jl")
 

--- a/src/services/services.jl
+++ b/src/services/services.jl
@@ -2,7 +2,7 @@ module Services
 
 using Compat
 
-import Base: convert, parse, box, unbox, ==, show
+import Base: convert, parse, box, unbox, ==, show, hash
 
 include("accession.jl")
 

--- a/src/services/services.jl
+++ b/src/services/services.jl
@@ -2,7 +2,7 @@ module Services
 
 using Compat
 
-import Base: parse, ==, show, hash, ismatch
+import Base: parse, ==, show, hash, ismatch, isless
 
 include("accession.jl")
 

--- a/src/services/services.jl
+++ b/src/services/services.jl
@@ -1,6 +1,7 @@
 module Services
 
 using Compat
+using Docile
 
 import Base: parse, ==, show, hash, ismatch, isless
 

--- a/src/services/services.jl
+++ b/src/services/services.jl
@@ -1,0 +1,9 @@
+module Services
+
+using Compat
+
+import Base: convert, parse, box, unbox, ==, show
+
+include("accession.jl")
+
+end

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -2,5 +2,36 @@ module TestServices
 
 using FactCheck
 using Bio
+using Bio.Services
+
+facts("Accession") do
+    context("Entrez Gene") do
+        # SMARCB1: Homo sapiens
+        smarcb1 = parse(Accession{EntrezGene}, "6598")
+        @fact string(smarcb1) => "6598"
+        @fact smarcb1 == "6598" => true
+        @fact "6598" == smarcb1 => true
+        # SMARCB1: Zonotrichia albicollis
+        smarcb1 = parse(Accession{EntrezGene}, "102067278")
+        @fact string(smarcb1) => "102067278"
+    end
+
+    context("GenBank") do
+        x = parse(Accession{GenBank}, "U46667.1")
+        @fact x == "U46667.1" => true
+        @fact string(x) => "U46667.1"
+    end
+
+    context("RefSeq") do
+        @fact parse(Accession{RefSeq}, "NC_000022.11") |> string => "NC_000022.11"
+        @fact parse(Accession{RefSeq}, "XM_011530345.1") |> string => "XM_011530345.1"
+        @fact parse(Accession{RefSeq}, "XP_011528647.1") |> string => "XP_011528647.1"
+    end
+
+    context("Gene Ontology") do
+        # SWI/SNF complex
+        @fact parse(Accession{GOTerm}, "GO:0016514") |> string => "GO:0016514"
+    end
+end
 
 end # TestServices

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -1,6 +1,7 @@
 module TestServices
 
 using FactCheck
+using Compat
 using Bio
 using Bio.Services
 
@@ -25,6 +26,25 @@ facts("Accession Number") do
         for (s, accession) in zip(ss, sort(accessions))
             @fact string(accession) => s
         end
+    end
+
+    context("Versioned Encoding") do
+        Versioned = Bio.Services.Versioned
+        aaa = Versioned("AAA")
+        aaa′ = Versioned("AAA")
+        aaa1 = Versioned{ASCIIString}("AAA", 0x01)
+        aaa2 = Versioned{ASCIIString}("AAA", 0x02)
+        bbb = Versioned("BBB")
+        bbb1 = Versioned{ASCIIString}("BBB", 0x01)
+        @fact aaa == aaa′ => true
+        @fact aaa == aaa1 => false
+        @fact aaa == bbb  => false
+        @fact aaa < aaa′ => false
+        @fact aaa < aaa1 < aaa2 => true
+        @fact aaa < bbb  < bbb1 => true
+        @fact hash(aaa) == hash(aaa′) => true
+        @fact hash(aaa) == hash(aaa1) => false
+        @fact hash(aaa) == hash(bbb)  => false
     end
 
     context("Entrez Gene") do
@@ -59,6 +79,7 @@ facts("Accession Number") do
         end
         test_order(:GenBank, list)
         @fact_throws parse(Accession{:GenBank}, "12345") "no prefix"
+        @fact_throws parse(Accession{:GenBank}, "U12345.300") "too large version"
     end
 
     context("RefSeq") do
@@ -77,6 +98,7 @@ facts("Accession Number") do
         end
         test_order(:RefSeq, list)
         @fact_throws parse(Accession{:RefSeq}, "XX_000022.1") "invalid prefix"
+        @fact_throws parse(Accession{:RefSeq}, "XP_011528647.300") "too large version"
     end
 
     context("Consensus CDS (CCDS)") do
@@ -91,6 +113,7 @@ facts("Accession Number") do
         end
         test_order(:CCDS, list)
         @fact_throws parse(Accession{:CCDS}, "CDS1234.1") "invalid prefix"
+        @fact_throws parse(Accession{:CCDS}, "CCDS5251.300") "too large version"
     end
 
     context("Ensembl") do
@@ -102,6 +125,7 @@ facts("Accession Number") do
             test_base(:Ensembl, s, guess=true)
         end
         test_order(:Ensembl, list)
+        @fact_throws parse(Accession{:Ensembl}, "ENSG00000139618.300") "too large version"
     end
 
     context("Gene Ontology") do

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -11,9 +11,11 @@ facts("Accession Number") do
         @fact string(accession) => strip(s)
         @fact accession == s => true
         @fact s == accession => true
-        @fact accession == parse(Accession{sym}, s) => true
+        @fact parse(Accession{sym}, s) => accession
+        @fact parse(Accession{sym}, convert(ASCIIString, s)) => accession
+        @fact parse(Accession{sym}, convert(UTF8String, s)) => accession
         if guess
-            @fact accession == Accession(s) => true
+            @fact Accession(s) => accession
         end
     end
 
@@ -94,6 +96,20 @@ facts("Accession Number") do
         @fact_throws parse(Accession{:GeneOntology}, "GO:123456") "short number"
         @fact_throws parse(Accession{:GeneOntology}, "GO:12345678") "long number"
         @fact_throws parse(Accession{:GeneOntology}, "GX:1234567") "invalid prefix"
+    end
+
+    context("UniProt") do
+        list = """
+        A2BC19
+        P12345
+        A0A022YWF9
+         A0A022YWF9 \t 
+        """ |> chomp
+        for s in split(list, '\n')
+            test_base(:UniProt, s, guess=true)
+        end
+        @fact_throws parse(Accession{:UniProt}, "P1234") "short number"
+        @fact_throws parse(Accession{:UniProt}, "P123456") "long number"
     end
 end
 

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -2,11 +2,12 @@ module TestServices
 
 using FactCheck
 using Compat
+using URIParser
 using Bio
 using Bio.Services
 
 facts("Accession Number") do
-    function test_base(sym::Symbol, s::String; guess=false)
+    function test_base(sym::Symbol, s::String; guess=false, nouri=false)
         accession = parse(Accession{sym}, s)
         @fact isa(accession, Accession{sym}) => true
         @fact string(accession) => strip(s)
@@ -18,6 +19,9 @@ facts("Accession Number") do
         @fact parse(Accession{sym}, convert(UTF8String, s)) => accession
         if guess
             @fact Accession(s) => accession
+        end
+        if !nouri
+            @fact isa(uri(accession), URI) => true
         end
     end
 
@@ -83,6 +87,7 @@ facts("Accession Number") do
 
     context("GenBank") do
         list = split(chomp("""
+        AB082923.1
         DL128137
         DL128137.1
         JL971710
@@ -123,6 +128,7 @@ facts("Accession Number") do
         CCDS5251
         CCDS5251.1
         CCDS5251.2
+        CCDS11118.1
         """))
         for s  in list
             test_base(:CCDS, s, guess=true)
@@ -136,9 +142,10 @@ facts("Accession Number") do
         list = split(chomp("""
         ENSG00000139618
         ENSG00000139618.13
+        ENSG00000141510
         """))
         for s in list
-            test_base(:Ensembl, s, guess=true)
+            test_base(:Ensembl, s, guess=true, nouri=true)
         end
         test_order(:Ensembl, list)
         @fact_throws parse(Accession{:Ensembl}, "ENSG00000139618.300") "too large version"
@@ -148,6 +155,7 @@ facts("Accession Number") do
         list = split(chomp("""
         GO:0000003
         GO:0016514
+        GO:0030330
         GO:0044183
         GO:0044848
         GO:2001306
@@ -167,6 +175,7 @@ facts("Accession Number") do
         A2BC19
         N1QTE2
         O55743
+        P04637
         P12345
         Q197B5
         Q6GZX4

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -22,7 +22,6 @@ facts("Accession Number") do
         end
         @fact_throws parse(Accession{:EntrezGene}, "-1234") "negative"
         @fact_throws parse(Accession{:EntrezGene}, "0x1234") "alphabet"
-        # TODO: this fails
         @fact_throws parse(Accession{:EntrezGene}, "4294967296") "too large"
     end
 
@@ -58,6 +57,8 @@ facts("Accession Number") do
             @fact refseq == parse(Accession{:RefSeq}, s) => true
             @fact refseq == Accession(s) => true
         end
+        @fact_throws parse(Accession{:RefSeq}, "NC_000022") "no version"
+        @fact_throws parse(Accession{:RefSeq}, "XX_000022.1") "invalid prefix"
     end
 
     context("Gene Ontology") do
@@ -75,6 +76,9 @@ facts("Accession Number") do
             @fact go == parse(Accession{:GeneOntology}, s) => true
             @fact go == Accession(s) => true
         end
+        @fact_throws parse(Accession{:GeneOntology}, "GO:123456") "short number"
+        @fact_throws parse(Accession{:GeneOntology}, "GO:12345678") "long number"
+        @fact_throws parse(Accession{:GeneOntology}, "GX:1234567") "invalid prefix"
     end
 end
 

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -4,33 +4,43 @@ using FactCheck
 using Bio
 using Bio.Services
 
-facts("Accession") do
+facts("Accession Number") do
     context("Entrez Gene") do
         # SMARCB1: Homo sapiens
         smarcb1 = parse(Accession{EntrezGene}, "6598")
         @fact string(smarcb1) => "6598"
         @fact smarcb1 == "6598" => true
+        @fact smarcb1 == "6599" => false
         @fact "6598" == smarcb1 => true
+        @fact "6599" == smarcb1 => false
+        @fact smarcb1 => parse(Accession{EntrezGene}, "6598")
         # SMARCB1: Zonotrichia albicollis
         smarcb1 = parse(Accession{EntrezGene}, "102067278")
         @fact string(smarcb1) => "102067278"
+        @fact hash(smarcb1) => hash(parse(Accession{EntrezGene}, "102067278"))
     end
 
     context("GenBank") do
         x = parse(Accession{GenBank}, "U46667.1")
         @fact x == "U46667.1" => true
         @fact string(x) => "U46667.1"
+        @fact hash(x) => hash(parse(Accession{GenBank}, "U46667.1"))
     end
 
     context("RefSeq") do
         @fact parse(Accession{RefSeq}, "NC_000022.11") |> string => "NC_000022.11"
         @fact parse(Accession{RefSeq}, "XM_011530345.1") |> string => "XM_011530345.1"
         @fact parse(Accession{RefSeq}, "XP_011528647.1") |> string => "XP_011528647.1"
+        x = parse(Accession{RefSeq}, "NC_000022.11")
+        @fact hash(x) => hash(parse(Accession{RefSeq}, "NC_000022.11"))
     end
 
     context("Gene Ontology") do
         # SWI/SNF complex
-        @fact parse(Accession{GOTerm}, "GO:0016514") |> string => "GO:0016514"
+        x = parse(Accession{GOTerm}, "GO:0016514")
+        @fact string(x) => "GO:0016514"
+        @fact x == "GO:0016514" => true
+        @fact hash(x) => hash(parse(Accession{GOTerm}, "GO:0016514"))
     end
 end
 

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -65,6 +65,22 @@ facts("Accession Number") do
         @fact_throws parse(Accession{:EntrezGene}, "4294967296") "too large"
     end
 
+    context("GI") do
+        list = split(chomp("""
+        22539468
+        42406218
+        89161185
+        568815597
+        """))
+        for s in list
+            test_base(:GI, s)
+        end
+        test_order(:GI, list)
+        @fact_throws parse(Accession{:GI}, "0123") "starting with zero"
+        @fact_throws parse(Accession{:GI}, "1a2539468") "alphabet"
+        @fact_throws parse(Accession{:GI}, "22539468.1") "versioned"
+    end
+
     context("GenBank") do
         list = split(chomp("""
         DL128137
@@ -101,7 +117,7 @@ facts("Accession Number") do
         @fact_throws parse(Accession{:RefSeq}, "XP_011528647.300") "too large version"
     end
 
-    context("Consensus CDS (CCDS)") do
+    context("CCDS") do
         list = split(chomp("""
         CCDS1.1
         CCDS5251

--- a/test/services/test_services.jl
+++ b/test/services/test_services.jl
@@ -6,41 +6,75 @@ using Bio.Services
 
 facts("Accession Number") do
     context("Entrez Gene") do
-        # SMARCB1: Homo sapiens
-        smarcb1 = parse(Accession{EntrezGene}, "6598")
-        @fact string(smarcb1) => "6598"
-        @fact smarcb1 == "6598" => true
-        @fact smarcb1 == "6599" => false
-        @fact "6598" == smarcb1 => true
-        @fact "6599" == smarcb1 => false
-        @fact smarcb1 => parse(Accession{EntrezGene}, "6598")
-        # SMARCB1: Zonotrichia albicollis
-        smarcb1 = parse(Accession{EntrezGene}, "102067278")
-        @fact string(smarcb1) => "102067278"
-        @fact hash(smarcb1) => hash(parse(Accession{EntrezGene}, "102067278"))
+        list = """
+        1
+        6598
+        105352660
+         6598 \t 
+        """ |> chomp
+        for s in split(list, '\n')
+            geneid = parse(Accession{:EntrezGene}, s)
+            @fact isa(geneid, Accession{:EntrezGene}) => true
+            @fact string(geneid) => strip(s)
+            @fact geneid == s => true
+            @fact s == geneid => true
+            @fact geneid == parse(Accession{:EntrezGene}, s) => true
+        end
+        @fact_throws parse(Accession{:EntrezGene}, "-1234") "negative"
+        @fact_throws parse(Accession{:EntrezGene}, "0x1234") "alphabet"
+        # TODO: this fails
+        @fact_throws parse(Accession{:EntrezGene}, "4294967296") "too large"
     end
 
     context("GenBank") do
-        x = parse(Accession{GenBank}, "U46667.1")
-        @fact x == "U46667.1" => true
-        @fact string(x) => "U46667.1"
-        @fact hash(x) => hash(parse(Accession{GenBank}, "U46667.1"))
+        list = """
+        U46667.1
+        DL128137.1
+         DL128137.1 \t 
+        """ |> chomp
+        for s in split(list, '\n')
+            genbank = parse(Accession{:GenBank}, s)
+            @fact isa(genbank, Accession{:GenBank}) => true
+            @fact string(genbank) => strip(s)
+            @fact genbank == s => true
+            @fact s == genbank => true
+            @fact genbank == parse(Accession{:GenBank}, s) => true
+        end
     end
 
     context("RefSeq") do
-        @fact parse(Accession{RefSeq}, "NC_000022.11") |> string => "NC_000022.11"
-        @fact parse(Accession{RefSeq}, "XM_011530345.1") |> string => "XM_011530345.1"
-        @fact parse(Accession{RefSeq}, "XP_011528647.1") |> string => "XP_011528647.1"
-        x = parse(Accession{RefSeq}, "NC_000022.11")
-        @fact hash(x) => hash(parse(Accession{RefSeq}, "NC_000022.11"))
+        list = """
+        NC_000022.11
+        XM_011530345.1
+        XP_011528647.1
+         XP_011528647.1 \t 
+        """ |> chomp
+        for s in split(list, '\n')
+            refseq = parse(Accession{:RefSeq}, s)
+            @fact isa(refseq, Accession{:RefSeq}) => true
+            @fact string(refseq) => strip(s)
+            @fact refseq == s => true
+            @fact s == refseq => true
+            @fact refseq == parse(Accession{:RefSeq}, s) => true
+            @fact refseq == Accession(s) => true
+        end
     end
 
     context("Gene Ontology") do
-        # SWI/SNF complex
-        x = parse(Accession{GOTerm}, "GO:0016514")
-        @fact string(x) => "GO:0016514"
-        @fact x == "GO:0016514" => true
-        @fact hash(x) => hash(parse(Accession{GOTerm}, "GO:0016514"))
+        list = """
+        GO:0016514
+        GO:0044848
+         GO:0016514 \t 
+        """ |> chomp
+        for s in split(list, '\n')
+            go = parse(Accession{:GeneOntology}, s)
+            @fact isa(go, Accession{:GeneOntology}) => true
+            @fact string(go) => strip(s)
+            @fact go == s => true
+            @fact s == go => true
+            @fact go == parse(Accession{:GeneOntology}, s) => true
+            @fact go == Accession(s) => true
+        end
     end
 end
 


### PR DESCRIPTION
Since accession numbers are routinely used in bioinformatics, it would be worth considering to define accession types in Julia.
This is a quick, suboptimal and incomplete trial to implement accession types for four databases: Entrez gene, GenBank, RefSeq and Gene Ontology.

Advantages (I think) of accession types over simple strings are:
- more explicit meaning
- normalized representation
- smaller footprint in size
- faster operation (e.g. comparison, hashing)

Disadvantages are:
- laborious type definition
- overhead of data conversion

Here I've implemented a few useful tools:
- equality test with string accession numbers (`=={T}(x::Accession{T}, y::String)`)
- open a web browser and access a database entry quickly (`browse(x::Accession)`)

And other tools I imagine:
- quickly `download` an entry with accession
- ID conversions and cross references

I'd like to know your opinions about my proposal.

Thank you.
