### PR TITLE
[RFC] Interval Coverage

### DIFF
--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -180,3 +180,18 @@ function alphanum_isless(a::String, b::String)
     return j <= length(b)
 end
 
+
+@doc """
+A type deriving `IntervalStream{T}` must be iterable and produce
+Interval{T} objects in sorted order.
+""" ->
+abstract IntervalStream{T}
+
+
+typealias IntervalStreamOrArray{T} Union(Vector{Interval{T}}, IntervalStream{T})
+
+
+function metadatatype{T}(::IntervalStream{T})
+    return T
+end
+

--- a/src/intervals/intervals.jl
+++ b/src/intervals/intervals.jl
@@ -18,12 +18,12 @@ import Bio: FileFormat
 
 export Strand, Interval, IntervalCollection, IntervalStream,
        STRAND_NA, STRAND_POS, STRAND_NEG, STRAND_BOTH,
-       isoverlapping, BED, BEDMetadata
+       coverage, isoverlapping, BED, BEDMetadata
 
 include("interval.jl")
 include("stream_buffer.jl")
-include("intervalstream.jl")
 include("intervalcollection.jl")
+include("intervalstream.jl")
 
 # Parsing file types
 include("bed.jl")

--- a/src/intervals/intervalstream.jl
+++ b/src/intervals/intervalstream.jl
@@ -1,4 +1,5 @@
 
+using Base.Collections: heappush!, heappop!
 
 # IntervalStreams
 # ---------------
@@ -6,21 +7,6 @@
 # Often we'd rather avoid reading a large interval dataset into an
 # IntervalCollection. We can still do efficient intersections if we can assume
 # the data is sorted
-
-
-@doc """
-A type deriving `IntervalStream{T}` must be iterable and produce
-Interval{T} objects in sorted order.
-""" ->
-abstract IntervalStream{T}
-
-
-typealias IntervalStreamOrArray{T} Union(Vector{Interval{T}}, IntervalStream{T})
-
-
-function metadatatype{T}(::IntervalStream{T})
-    return T
-end
 
 
 type IntervalStreamIntersectIterator{S, T, SS, TS}
@@ -206,3 +192,137 @@ end
 
 
 # TODO: IntervalCollection(stream::IntervalStream) constructor.
+
+
+# Helper function for coverage. Process remaining interval end points after
+# all intervals have been read.
+function coverage_process_lasts_heap!(cov::IntervalCollection{Uint32},
+                                      current_coverage, coverage_seqname,
+                                      coverage_first, lasts)
+    while !isempty(lasts)
+        pos = heappop!(lasts)
+        if pos == coverage_first - 1
+            current_coverage -= 1
+        else
+            @assert pos >= coverage_first
+            push!(cov, Interval{Uint32}(coverage_seqname, coverage_first,
+                                        pos, STRAND_BOTH, current_coverage))
+            current_coverage -= 1
+            coverage_first = pos + 1
+        end
+    end
+    @assert current_coverage == 0
+end
+
+@doc """
+Compute the coverage of a collection of intervals.
+
+# Args
+  * `intervals`: any IntervalStream
+
+# Returns
+An IntervalCollection that contains run-length encoded coverage data.
+
+E.g. for intervals like
+```
+    [------]     [------------]
+       [---------------]
+```
+
+this function would return a new set of disjoint intervals with annotated
+coverage like:
+```
+    [1][-2-][-1-][--2--][--1--]
+```
+""" ->
+function coverage(stream::IntervalStreamOrArray,
+                  seqname_isless::Function=isless)
+    cov = IntervalCollection{Uint32}()
+    lasts = Int64[]
+
+    stream_state = start(stream)
+    if done(stream, stream_state)
+        return cov
+    end
+
+    # TODO: How are we going to do this in a strand specific manner??
+    # Just filter the stream?
+
+    current_coverage = 0
+    coverage_seqname = ""
+    coverage_first = 0
+    last_interval_first = 0
+    interval, stream_state = next(stream, stream_state)
+    while true
+        if interval.seqname != coverage_seqname
+            coverage_process_lasts_heap!(cov, current_coverage, coverage_seqname,
+                                         coverage_first, lasts)
+            if !(isempty(coverage_seqname) || seqname_isless(coverage_seqname, interval.seqname))
+                error("Intervals must be sorted to compute coverage.")
+            end
+
+            coverage_seqname = interval.seqname
+            current_coverage = 0
+            coverage_first = 0
+            last_interval_first = 0
+        end
+
+        if interval.first < last_interval_first
+            error("Intervals must be sorted to compute coverage.")
+        end
+
+        if !isempty(lasts) && lasts[1] < first(interval)
+            pos = heappop!(lasts)
+            if first(interval) == pos + 1
+                heappush!(lasts, last(interval))
+                if done(stream, stream_state)
+                    break
+                end
+                last_interval_first = first(interval)
+                interval, stream_state = next(stream, stream_state)
+            elseif pos == coverage_first - 1
+                current_coverage -= 1
+            else
+                @assert pos >= coverage_first
+                push!(cov, Interval{Uint32}(coverage_seqname, coverage_first,
+                                            pos, STRAND_BOTH, current_coverage))
+                current_coverage -= 1
+                coverage_first = pos + 1
+            end
+        else
+            if coverage_first == 0
+                coverage_first = first(interval)
+                current_coverage = 1
+            elseif coverage_first == first(interval)
+                current_coverage += 1
+            else
+                if current_coverage > 0
+                    push!(cov, Interval{Uint32}(coverage_seqname, coverage_first,
+                                                first(interval) - 1, STRAND_BOTH,
+                                                current_coverage))
+                end
+                current_coverage += 1
+                coverage_first = first(interval)
+            end
+
+            heappush!(lasts, last(interval))
+            if done(stream, stream_state)
+                break
+            end
+            last_interval_first = first(interval)
+            interval, stream_state = next(stream, stream_state)
+        end
+    end
+
+    coverage_process_lasts_heap!(cov, current_coverage, coverage_seqname,
+                                 coverage_first, lasts)
+
+    return cov
+end
+
+
+function coverage(ic::IntervalCollection)
+    return coverage(ic, alphanum_isless)
+end
+
+


### PR DESCRIPTION
This adds a function `coverage` that will compute coverage over an `IntervalStream`. It works like the [`genomecov -bg`](http://bedtools.readthedocs.org/en/latest/content/tools/genomecov.html) command in bedtools.

Performance is really good compared to bedtools:
```bash
» wc -l motifs.bed
 3272681 motifs.bed
» time bedtools genomecov -bg -i motifs.bed -g hg19.chromSizes > /dev/null
24.92s user 8.56s system 98% cpu 33.841 total
```

```julia
@time coverage(read("motifs.bed", BED))
   7.922 seconds      (59164 k allocations: 2371 MB, 30.36% gc time)
```

I actually think ours can be significantly faster. The bottleneck is inserting intervals into an `IntervalCollection`, and that can be done faster with bulk insertion (i.e. collect all the intervals in an array and then insert in one go) which I haven't implemented yet, but isn't hard.

This is complete and self-contained, and should be ready to merge after #32 and #50, and will be required for #51 to write summary data for BigBed files.