### PR TITLE
Blastwrapper

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ Colors
 IntervalTrees
 Iterators
 Libz
+LightXML

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -10,5 +10,6 @@ include("util/Util.jl")
 include("intervals/Intervals.jl")
 include("align/Align.jl")
 include("structure/Structure.jl")
+include("tools/blast/Blast.jl")
 
 end # module Bio

--- a/src/tools/blast/Blast.jl
+++ b/src/tools/blast/Blast.jl
@@ -1,0 +1,14 @@
+module Blast
+
+using Bio.Seq,
+      Bio.Align,
+      LightXML
+
+export blastn,
+       blastp,
+       readblastXML,
+       BlastResult
+
+include("blastcommandline.jl")
+
+end # module Blast

--- a/src/tools/blast/README.md
+++ b/src/tools/blast/README.md
@@ -1,0 +1,30 @@
+##Blast Tools module for Bio.jl - Spec and Roadmap
+
+Bio.jl needs a way to run BLAST and other command line tools commonly used in biology applications, taking inputs and capturing outputs in Bio.jl formats.
+
+###Minimum requirements for BLAST module
+With Blast+ installed on users' system:
+
+**Input**
+
+- [x] accept seq object or file name as query and subject
+    - [x] accept single sequence objects
+    - [x] accept multi-sequence objects
+- [x] blastn, blastp, ~~blastall~~
+    - [ ] others?
+- [x] accept flags for search modification
+- [x] take/parse blast xml output
+
+**Output**
+
+- [x] return alignment object or strings for alignment
+- [x] return stats object w/other information
+- [ ] allow return of other blast outputs (tsv, csv etc)
+
+###Other Useful Features
+
+- [ ] bundle blast package from within Bio.jl (is this possible?)
+- [ ] pull queries/subjects from NCBI
+    - [ ] incorporate into Bio.jl formats
+- [ ] run Blast through NCBI servers instead of locally
+- [ ] ...

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -1,0 +1,170 @@
+# wrapper for BLAST+ command line functions
+
+immutable BlastResult
+    bitscore::Float64
+    expect::Float64
+    queryname::ASCIIString
+    hitname::ASCIIString
+    hit::BioSequence
+    alignment::AlignedSequence
+end
+
+"""
+`readblastXML(blastrun::ASCIIString)`
+Parse XML output of a blast run. Input is an XML string eg:
+```julia
+results = readall(open("blast_results.xml")) # need to use `readstring` instead of `readall` for v0.5
+readblastXML(results)
+```
+
+Returns Vector{BlastResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
+"""
+function readblastXML(blastrun::ASCIIString; seqtype="nucl")
+    xdoc = parse_string(blastrun)
+    xroot = root(xdoc)
+    params = get_elements_by_tagname(xroot, "BlastOutput_param")
+    iterations = get_elements_by_tagname(xroot, "BlastOutput_iterations")
+    results = BlastResult[]
+    for iteration in collect(child_elements(iterations[1]))
+        queryname = content(find_element(iteration, "Iteration_query-def"))
+        hits = get_elements_by_tagname(iteration, "Iteration_hits")
+        for hit in collect(child_elements(hits[1]))
+            hitname = content(find_element(hit, "Hit_def"))
+            hsps = get_elements_by_tagname(hit, "Hit_hsps")
+            for hsp in collect(child_elements(hsps[1]))
+                if seqtype == "nucl"
+                    qseq = BioSequence{DNAAlphabet{4}}(content(find_element(hsp, "Hsp_qseq")))
+                    hseq = BioSequence{DNAAlphabet{4}}(content(find_element(hsp, "Hsp_hseq")))
+                elseif seqtype == "prot"
+                    qseq = AminoAcidSequence(content(find_element(hsp, "Hsp_qseq")))
+                    hseq = AminoAcidSequence(content(find_element(hsp, "Hsp_hseq")))
+                else
+                    throw(error("Please use \"nucl\" or \"prot\" for seqtype"))
+                end
+
+                aln = AlignedSequence(qseq, hseq)
+                bitscore = float(content(find_element(hsp, "Hsp_bit-score")))
+                expect = float(content(find_element(hsp, "Hsp_evalue")))
+                push!(results, BlastResult(bitscore, expect, queryname, hitname, hseq, aln))
+            end
+        end
+    end
+    return results
+end
+
+"""
+`readblastXML(blastrun::Cmd)`
+Parse command line blast query with XML output. Input is the blast command line command.
+
+Returns Vector{BlastResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
+"""
+function readblastXML(blastrun::Cmd; seqtype="nucl")
+    # need to use `readstring` instead of `readall` for v0.5
+    readblastXML(readall(blastrun), seqtype=seqtype)
+end
+
+
+"""
+`blastn(query, subject, flags...)``
+Runs blastn on `query` against `subject`.
+    Subjects and queries may be file names (as strings), BioSequence{DNAAlphabet{4}} type or
+    Array of BioSequence{DNAAlphabet{4}}.
+    May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
+"""
+function blastn(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
+    if db
+        results = readblastXML(`blastn -query $query -db $subject $flags -outfmt 5`)
+    else
+        results = readblastXML(`blastn -query $query -subject $subject $flags -outfmt 5`)
+    end
+    return results
+end
+
+function blastn(query::BioSequence{DNAAlphabet{4}}, subject::BioSequence{DNAAlphabet{4}}, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastn(querypath, subjectpath, flags)
+end
+
+function blastn{S <: BioSequence{DNAAlphabet{4}}}(query::BioSequence{DNAAlphabet{4}}, subject::Vector{S}, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastn(querypath, subjectpath, flags)
+end
+
+function blastn(query::BioSequence{DNAAlphabet{4}}, subject::AbstractString, flags=[]; db::Bool=false)
+    querypath = makefasta(query)
+    if db
+        blastn(querypath, subject, flags, db=true)
+    else
+        blastn(querypath, subject, flags)
+    end
+end
+
+function blastn{S <: BioSequence{DNAAlphabet{4}}}(query::Vector{S}, subject::Vector{S}, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastn(querypath, subjectpath, flags)
+end
+
+"""
+`blastp(query, subject, flags...)``
+Runs blastn on `query` against `subject`.
+    Subjects and queries may be file names (as strings), `BioSequence{AminoAcidSequence}` type or
+    Array of `BioSequence{AminoAcidSequence}`.
+    May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
+"""
+function blastp(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
+    if db
+        results = readblastXML(`blastp -query $query -db $subject $flags -outfmt 5`, seqtype = "prot")
+    else
+        results = readblastXML(`blastp -query $query -subject $subject $flags -outfmt 5`, seqtype = "prot")
+    end
+end
+
+function blastp(query::AminoAcidSequence, subject::AminoAcidSequence, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastp(querypath, subjectpath, flags)
+end
+
+function blastp{S <: AminoAcidSequence}(query::AminoAcidSequence, subject::Vector{S}, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastp(querypath, subjectpath, flags)
+end
+
+function blastp(query::AminoAcidSequence, subject::AbstractString, flags=[]; db::Bool=false)
+    querypath = makefasta(query)
+    if db
+        blastp(querypath, subject, flags, db=true)
+    else
+        blastp(querypath, subject, flags)
+    end
+end
+
+function blastp{S <: AminoAcidSequence}(query::Vector{S}, subject::Vector{S}, flags=[])
+    querypath, subjectpath = makefasta(query), makefasta(subject)
+    blastp(querypath, subjectpath, flags)
+end
+
+"""
+`makefasta(sequence::BioSequence)`
+Create temporary fasta-formated file for blasting.
+"""
+function makefasta{T <: BioSequence}(sequence::T)
+    path, io = mktemp()
+    write(io, ">$path\n$(convert(AbstractString, sequence))\n")
+    close(io)
+    return path
+end
+
+"""
+`makefasta(sequence::Vector{BioSequence})`
+Create temporary multi fasta-formated file for blasting.
+"""
+function makefasta{T <: BioSequence}(sequences::Vector{T})
+    path, io = mktemp()
+    counter = 1
+    for sequence in sequences
+        write(io, ">$path$counter\n$(convert(AbstractString, sequence))\n")
+        counter += 1
+    end
+    close(io)
+    return path
+end

--- a/test/tools/runtests.jl
+++ b/test/tools/runtests.jl
@@ -21,12 +21,12 @@ path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
     nucldb = joinpath(path, "BLASTDB", "f002")
     nuclresults = joinpath(path, "BLASTDB", "f002.xml")
 
-    @test blastn(na1, na2)
-    @test blastn(na1, [na1, na2])
-    @test blastn([na1, na2], [na1, na2])
-    @test blastn(na1, nucldb, db=true)
-    @test blastn(na1, fna)
-    @test blastn(fna, nucldb, db=true)
+    @test typeof(blastn(na1, na2)) == Array{BlastResult, 1}
+    @test typeof(blastn(na1, [na1, na2])) == Array{BlastResult, 1}
+    @test typeof(blastn([na1, na2], [na1, na2])) == Array{BlastResult, 1}
+    @test typeof(blastn(na1, nucldb, db=true)) == Array{BlastResult, 1}
+    @test typeof(blastn(na1, fna)) == Array{BlastResult, 1}
+    @test typeof(blastn(fna, nucldb, db=true)) == Array{BlastResult, 1}
 
 end
 
@@ -37,12 +37,12 @@ end
     protdb = joinpath(path, "BLASTDB", "cysprot")
     protresults = joinpath(path, "BLASTDB", "cysprot.xml")
 
-    @test blastp(aa1, aa2)
-    @test blastp(aa1, [aa1, aa2])
-    @test blastp([aa1, aa2], [aa1, aa2])
-    @test blastp(aa1, protdb, db=true)
-    @test blastp(aa1, faa)
-    @test blastp(faa, protdb, db=true)
+    @test typeof(blastp(aa1, aa2)) == Array{BlastResult, 1}
+    @test typeof(blastp(aa1, [aa1, aa2])) == Array{BlastResult, 1}
+    @test typeof(blastp([aa1, aa2], [aa1, aa2])) == Array{BlastResult, 1}
+    @test typeof(blastp(aa1, protdb, db=true)) == Array{BlastResult, 1}
+    @test typeof(blastp(aa1, faa)) == Array{BlastResult, 1}
+    @test typeof(blastp(faa, protdb, db=true)) == Array{BlastResult, 1}
 end
 
 end # TestTools

--- a/test/tools/runtests.jl
+++ b/test/tools/runtests.jl
@@ -1,4 +1,48 @@
 module TestTools
 
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+using Bio.Seq,
+      Bio.Blast,
+      TestFunctions
+
+get_bio_fmt_specimens()
+path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
+
+@testset "Blast+ blastn" begin
+    na1 = dna"CGGACCAGACGGACACAGGGAGAAGCTAGTTTCTTTCATGTGATTGANATNATGACTCTACTCCTAAAAGGGAAAAANCAATATCCTTGTTTACAGAAGAGAAACAAACAAGCCCCACTCAGCTCAGTCACAGGAGAGAN"
+    na2 = dna"CGGAGCCAGCGAGCATATGCTGCATGAGGACCTTTCTATCTTACATTATGGCTGGGAATCTTACTCTTTCATCTGATACCTTGTTCAGATTTCAAAATAGTTGTAGCCTTATCCTGGTTTTACAGATGTGAAACTTTCAA"
+    fna = joinpath(path, "FASTA", "f002.fasta")
+    nucldb = joinpath(path, "BLASTDB", "f002")
+    nuclresults = joinpath(path, "BLASTDB", "f002.xml")
+
+    @test blastn(na1, na2)
+    @test blastn(na1, [na1, na2])
+    @test blastn([na1, na2], [na1, na2])
+    @test blastn(na1, nucldb, db=true)
+    @test blastn(na1, fna)
+    @test blastn(fna, nucldb, db=true)
+
+end
+
+@testset "Blast+ blastp" begin
+    aa1 = aa"MWATLPLLCAGAWLLGVPVCGAAELSVNSLEKFHFKSWMSKHRKTYSTEEYHHRLQTFASNWRKINAHNNGNHTFKMALNQFSDMSFAEIKHKYLWSEPQNCSATKSNYLRGTGPYPPSVDWRKKGNFVSPVKNQGACGS"
+    aa2 = aa"MWTALPLLCAGAWLLSAGATAELTVNAIEKFHFTSWMKQHQKTYSSREYSHRLQVFANNWRKIQAHNQRNHTFKMGLNQFSDMSFAEIKHKYLWSEPQNCSATKSNYLRGTGPYPSSMDWRKKGNVVSPVKNQGACGSCW"
+    faa = joinpath(path, "FASTA", "cysprot.fasta")
+    protdb = joinpath(path, "BLASTDB", "cysprot")
+    protresults = joinpath(path, "BLASTDB", "cysprot.xml")
+
+    @test blastp(aa1, aa2)
+    @test blastp(aa1, [aa1, aa2])
+    @test blastp([aa1, aa2], [aa1, aa2])
+    @test blastp(aa1, protdb, db=true)
+    @test blastp(aa1, faa)
+    @test blastp(faa, protdb, db=true)
+end
 
 end # TestTools


### PR DESCRIPTION
## Blast Tools module for Bio.jl - Spec and Roadmap

Bio.jl needs a way to run BLAST and other command line tools commonly used in biology applications, taking inputs and capturing outputs in Bio.jl formats. 

### Minimum requirements for BLAST module
With Blast+ installed on users' system:

**Input**

- [x] accept seq object~~, string~~ or file as query and subject
    - [x] accept single sequence objects
    - [x] accept multi-sequence objects
- [x] blastn, blastp, blastall
    - [ ] others?
- [x] accept flags for search modification
- [x] take/parse blast xml output

**Output**

- [x] return alignment object or strings for alignment
- [x] return stats object w/other information
- [ ] allow return of other blast outputs (tsv, csv etc)

### Other Useful Features

- [ ] bundle blast package from within Bio.jl (is this possible?)
- [ ] pull queries/subjects from NCBI
    - [ ] incorporate into Bio.jl formats
- [ ] run Blast through NCBI servers instead of locally
- [ ] ... others?