### PR TITLE
speed up the getindex method with inlining

### DIFF
--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -542,7 +542,7 @@ function =={T}(a::NucleotideSequence{T}, b::NucleotideSequence{T})
 end
 
 # Get the nucleotide at position i, ignoring the N mask.
-function getnuc(T::Type, data::Vector{Uint64}, i::Integer)
+@inline function getnuc(T::Type, data::Vector{Uint64}, i::Integer)
     d, r = divrem32(i - 1)
     return convert(T, convert(Uint8, (data[d + 1] >>> (2*r)) & 0b11))
 end


### PR DESCRIPTION
Somewhat surprisingly, inlining the `getnuc` method makes `getindex` ~6x faster.

script:
```julia
using Bio.Seq

function loop(seq)
    x = zero(UInt)
    for i in 1:endof(seq)
        x += convert(UInt, seq[i])
    end
    x
end

let
    fasta = shift!(ARGS)
    for rec in read(fasta, FASTA)
        println(@time loop(rec.seq))
    end
end
```

input: chr1 of human

result:
```
Before:
  11.008 seconds      (225 M allocations: 3438 MB, 2.02% gc time)

After:
   1.674 seconds      (13866 allocations: 585 KB)
```

I cannot account for the huge memory allocations, but inlining diminishes this strange phenomenon.
There may be a bug in Julia.

---

```
julia> versioninfo()
Julia Version 0.4.0-dev+6350
Commit 9b14a7c* (2015-07-29 10:26 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin14.3.0)
  CPU: Intel(R) Core(TM) i5-4288U CPU @ 2.60GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Haswell)
  LAPACK: libopenblas
  LIBM: libopenlibm
  LLVM: libLLVM-3.3
```