### PR TITLE
import operators from Base explicitly

### DIFF
--- a/src/seq/seq.jl
+++ b/src/seq/seq.jl
@@ -3,9 +3,11 @@ module Seq
 using Compat
 using Base.Intrinsics
 
-import Base: convert, complement, getindex, show, length, start, next, done,
-             copy, reverse, show, endof, isless, clipboard, parse, repeat,
-             unsafe_copy!, read, read!, ==, *, |, &
+import Base: convert, complement, show, length, start, next, done, copy,
+             reverse, show, endof, isless, clipboard, parse, repeat,
+             unsafe_copy!, read, read!,
+             # operators
+             getindex, setindex!, ==, *, ^, |, &
 
 import Bio: FileFormat
 


### PR DESCRIPTION
`import Base.Operators` has been removed in Julia: https://github.com/JuliaLang/julia/pull/12235.
So we have to import all operators explicitly from the `Base` module from now on.
This pull request adds missing operators to the import list.