### PR TITLE
Remove newlines

### DIFF
--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -247,6 +247,18 @@ convert(::Type{String}, seq::AminoAcidSequence) = convert(String, [convert(Char,
 # Basic functions
 # ---------------
 
+function ==(a::AminoAcidSequence, b::AminoAcidSequence)
+    if (len = length(a)) != length(b)
+        return false
+    end
+    for i in 1:len
+        if a[i] != b[i]
+            return false
+        end
+    end
+    return true
+end
+
 function show(io::IO, seq::AminoAcidSequence)
     len = length(seq)
     write(io, "$(string(len))aa Sequence:\n ")
@@ -309,5 +321,5 @@ done(seq::AminoAcidSequence, i) = (i > seq.part.stop)
 
 # Enable building sequence literals like: aa"ACDEFMN"
 macro aa_str(seq, flags...)
-    return AminoAcidSequence(seq)
+    return AminoAcidSequence(remove_newlines(seq))
 end

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -639,11 +639,15 @@ end
 
 # Enable building sequence literals like: dna"ACGTACGT" and rna"ACGUACGU"
 macro dna_str(seq, flags...)
-    return DNASequence(seq)
+    return DNASequence(remove_newlines(seq))
 end
 
 macro rna_str(seq, flags...)
-    return RNASequence(seq)
+    return RNASequence(remove_newlines(seq))
+end
+
+function remove_newlines(seq)
+    return replace(seq, r"\r|\n", "")
 end
 
 

--- a/test/seq/test_seq.jl
+++ b/test/seq/test_seq.jl
@@ -393,6 +393,20 @@ facts("Nucleotides") do
                 @fact ==(rna"ACUGN", rna"ACUGA") --> false
                 @fact ==(rna"ACUGN", rna"ACUG") --> false
                 @fact ==(rna"ACUG", rna"ACUGN") --> false
+
+                a = dna"ACGTNACGTN"
+                b = dna"""
+                ACGTN
+                ACGTN
+                """
+                @fact ==(a, b) --> true
+
+                c = rna"ACUGNACUGN"
+                d = rna"""
+                ACUGN
+                ACUGN
+                """
+                @fact ==(c, d) --> true
             end
 
             context("Length") do

--- a/test/seq/test_seq.jl
+++ b/test/seq/test_seq.jl
@@ -1107,6 +1107,20 @@ facts("Aminoacids") do
             @fact all(Bool[check_concatenation(rand(1:10)) for _ in 1:100]) --> true
         end
 
+        context("Equality") do
+            seq = aa"ARNDCQEGHILKMFPSTWYVX"
+            @fact ==(seq, aa"ARNDCQEGHILKMFPSTWYVX") --> true
+            @fact ==(seq, aa"ARNDCQEGHILKMFPSTWYXV") --> false
+            @fact ==(seq, aa"ARNDCQEGHLKMFPSTWYVX")  --> false
+
+            seq′ = aa"""
+            ARNDCQEGHI
+            LKMFPSTWYV
+            X
+            """
+            @fact ==(seq, seq′) --> true
+        end
+
         context("Repetition") do
             function check_repetition(n)
                 chunk = random_aa(rand(100:300))


### PR DESCRIPTION
Sorry for mixing several topics in a pull request:

1. I often want to write sequences in a file or an interactive session with multiple lines literal, but `dna"..."` doesn't allow that. These newlines will be removed in this pull request.
2. I've found that `AminoAcidSequence` doesn't have the `==` method. I added it and some tests.
3. The unit test is failing due to the sequence parsing (or format specimens?). I hid them for a moment just because it was noisy.

@dcjones Could you fix the testing problem when you have time? I'm not perfectly sure what's going on here.