### PR TITLE
define hash function for Alphabet to compile safely

### DIFF
--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -28,6 +28,8 @@ function Base.&(a::Alphabet, b::Alphabet)
     return convert(Alphabet, convert(Uint16, a) & convert(Uint16, b))
 end
 
+# for safe module precompilation
+Base.hash(a::Alphabet) = hash(convert(UInt16, a))
 
 "`Alphabet` value indicating no compatible alphabets."
 const EMPTY_ALPHABET = convert(Alphabet, @compat UInt16(0))


### PR DESCRIPTION
As suggested in #72 , hash values must be stable to precompile the Bio.Seq module.
This defines the `hash` function for `Alphabet` instead of initializing the `alphabet_type` global dictionary in `__init__()`.