### PR TITLE
import the write method into Bio.Seq from Base

### DIFF
--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -101,6 +101,7 @@ import Base:
     unsafe_copy!,
     read,
     read!,
+    write,
     open,
     eltype,
     getindex,

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -212,6 +212,14 @@ facts("Nucleotides") do
         end
     end
 
+    context("Show") do
+        buf = IOBuffer()
+        for nt in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N]
+            show(buf, nt)
+        end
+        @fact takebuf_string(buf) --> "ACGTN"
+    end
+
     context("Sequences") do
         function dna_complement(seq::AbstractString)
             seqc = Array(Char, length(seq))


### PR DESCRIPTION
We **REALLY** have to take the importing problem seriously.

This caused an error when printing a nucleotide:

```
julia> using Bio.Seq

julia> DNA_A
Error showing value of type Bio.Seq.DNANucleotide:
ERROR: MethodError: `write` has no method matching write(::Base.Terminals.TTYTerminal, ::Char)
you may have intended to import Base.write
Closest candidates are:
  write(::IO, ::Bio.Seq.SeqRecord{Bio.Seq.NucleotideSequence{Bio.Seq.DNANucleotide},Bio.Seq.FASTQMetadata})
 in show at /Users/kenta/.julia/v0.4/Bio/src/seq/nucleotide.jl:158
 in anonymous at show.jl:1278
 in with_output_limit at /usr/local/julia/v0.4/lib/julia/sys.dylib
 in showlimited at show.jl:1277
 in writemime at replutil.jl:4
 in display at REPL.jl:115
 in display at REPL.jl:118
 [inlined code] from multimedia.jl:151
 in display at multimedia.jl:162
 in print_response at REPL.jl:135
 in print_response at REPL.jl:122
 in anonymous at REPL.jl:624
 in run_interface at /usr/local/julia/v0.4/lib/julia/sys.dylib
 in run_frontend at /usr/local/julia/v0.4/lib/julia/sys.dylib
 in run_repl at /usr/local/julia/v0.4/lib/julia/sys.dylib
 in _start at /usr/local/julia/v0.4/lib/julia/sys.dylib
```