### PR TITLE
Round trip tests for reading/writing. And some bug fixes.

### DIFF
--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -155,6 +155,13 @@ function hash(field::StringField, h::UInt64)
 end
 
 
+function (==)(a::StringField, b::StringField)
+    return length(a) == length(b) &&
+        ccall(:memcmp, Cint, (Ptr{Void}, Ptr{Void}, Csize_t),
+              pointer(a.data, a.part.start), pointer(b.data, b.part.start), length(a)) == 0
+end
+
+
 function (==)(a::StringField, b::BufferedStreams.BufferedOutputStream)
     if a === b
         return true

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -337,7 +337,7 @@ function orphan!(seq::AminoAcidSequence, reorphan=false)
 end
 
 
-copy(seq::AminoAcidSequence) = orphan!(AminoAcidSequence(seq.data, seq.part, seq.mutable, false))
+copy(seq::AminoAcidSequence) = orphan!(AminoAcidSequence(seq.data, seq.part, seq.mutable, false), true)
 
 
 function setindex!(seq::AminoAcidSequence, nt::AminoAcid, i::Integer)
@@ -362,13 +362,13 @@ function copy!(seq::AminoAcidSequence, strdata::Vector{UInt8},
         error("Cannot copy! to immutable sequnce. Call `mutable!(seq)` first.")
     end
 
-    n = stoppos - startpos - 1
+    n = stoppos - startpos + 1
     if length(seq.data) < n
         resize!(seq.data, n)
     end
 
     for i in 1:n
-        seq.data[i] = convert(AminoAcid, strdata[startpos + i - 1])
+        seq.data[i] = convert(AminoAcid, Char(strdata[startpos + i - 1]))
     end
     seq.part = 1:n
 end

--- a/src/seq/fasta.jl
+++ b/src/seq/fasta.jl
@@ -15,6 +15,11 @@ function FASTAMetadata()
 end
 
 
+function (==)(a::FASTAMetadata, b::FASTAMetadata)
+    return a.description == b.description
+end
+
+
 function copy(metadata::FASTAMetadata)
     return FASTAMetadata(copy(metadata.description))
 end
@@ -41,8 +46,11 @@ end
 
 "Writes a FASTASeqRecord to an IO-stream (and obeys FASTAs max character constraint)"
 function Base.write{T}(io::IO, seqrec::SeqRecord{T, FASTAMetadata})
-    header = strip(string(">", seqrec.name, " ", seqrec.metadata.description))
-    write(io, header, "\n")
+    write(io, ">", seqrec.name)
+    if !isempty(seqrec.metadata.description)
+        write(io, " ", seqrec.metadata.description)
+    end
+    write(io, "\n")
     maxchars = 79
     counter = 1
     len = length(seqrec.seq)

--- a/src/seq/fasta.rl
+++ b/src/seq/fasta.rl
@@ -16,6 +16,11 @@ function FASTAMetadata()
 end
 
 
+function (==)(a::FASTAMetadata, b::FASTAMetadata)
+    return a.description == b.description
+end
+
+
 function copy(metadata::FASTAMetadata)
     return FASTAMetadata(copy(metadata.description))
 end
@@ -42,8 +47,11 @@ end
 
 "Writes a FASTASeqRecord to an IO-stream (and obeys FASTAs max character constraint)"
 function Base.write{T}(io::IO, seqrec::SeqRecord{T, FASTAMetadata})
-    header = strip(string(">", seqrec.name, " ", seqrec.metadata.description))
-    write(io, header, "\n")
+    write(io, ">", seqrec.name)
+    if !isempty(seqrec.metadata.description)
+        write(io, " ", seqrec.metadata.description)
+    end
+    write(io, "\n")
     maxchars = 79
     counter = 1
     len = length(seqrec.seq)

--- a/src/seq/fastq.rl
+++ b/src/seq/fastq.rl
@@ -22,6 +22,11 @@ function FASTQMetadata()
 end
 
 
+function (==)(a::FASTQMetadata, b::FASTQMetadata)
+    return a.description == b.description && a.quality == b.quality
+end
+
+
 function copy(metadata::FASTQMetadata)
     return FASTQMetadata(copy(metadata.description), copy(metadata.quality))
 end
@@ -73,23 +78,40 @@ end
 """
 Write a `FASTQSeqRecord` to `io`, as a valid FASTQ record.
 """
-function write(io::IO, seqrec::FASTQSeqRecord; offset::Integer=33,
+function write(io::IO, seqrec::FASTQSeqRecord; offset::Integer=-1,
                qualheader::Bool=false)
-    write(io, "@", seqrec.name, " ", seqrec.metadata.description, "\n")
+
+    # choose offset automatically
+    if offset < 0
+        if !isempty(seqrec.metadata.quality) && minimum(seqrec.metadata.quality) < 0
+            offset = 64 # solexa quality offset
+        else
+            offset = 33  # sanger
+        end
+    end
+
+    write(io, "@", seqrec.name)
+    if !isempty(seqrec.metadata.description)
+        write(io, " ", seqrec.metadata.description)
+    end
+    write(io, "\n")
 
     for c in seqrec.seq
         show(io, c)
     end
     write(io, "\n")
 
+    write(io, "+")
     if qualheader
-        write(io, "+", seqrec.name, " ", seqrec.metadata.description, "\n")
-    else
-        write(io, "+\n")
+        write(io, seqrec.name)
+        if !isempty(seqrec.metadata.description)
+            write(io, " ", seqrec.metadata.description)
+        end
     end
+    write(io, "\n")
 
     for q in seqrec.metadata.quality
-        write(io, char(q + offset))
+        write(io, Char(q + offset))
     end
     write(io, "\n")
 end

--- a/src/seq/seqrecord.jl
+++ b/src/seq/seqrecord.jl
@@ -36,6 +36,11 @@ function getindex(seqrec::SeqRecord, r::UnitRange)
 end
 
 
+function (==){T <: SeqRecord}(a::T, b::T)
+    return a.name == b.name && a.seq == b.seq && a.metadata == b.metadata
+end
+
+
 function copy{T <: SeqRecord}(seqrec::T)
     return T(copy(seqrec.name), copy(seqrec.seq), copy(seqrec.metadata))
 end

--- a/test/intervals/TestIntervals.jl
+++ b/test/intervals/TestIntervals.jl
@@ -341,18 +341,31 @@ facts("Interval Parsing") do
 
         function check_bed_parse(filename)
             # Reading from a stream
-            for seqrec in open(open(filename), BED)
+            for interval in open(open(filename), BED)
             end
 
             # Reading from a memory mapped file
-            for seqrec in open(filename, BED, memory_map=true)
+            for interval in open(filename, BED, memory_map=true)
             end
 
             # Reading from a regular file
-            for seqrec in open(filename, BED, memory_map=false)
+            for interval in open(filename, BED, memory_map=false)
             end
 
-            return true
+            # Check round trip
+            output = IOBuffer()
+            expected_entries = Any[]
+            for interval in open(filename, BED)
+                write(output, interval)
+                push!(expected_entries, interval)
+            end
+
+            read_entries = Any[]
+            for interval in open(takebuf_array(output), BED)
+                push!(read_entries, interval)
+            end
+
+            return expected_entries == read_entries
         end
 
         path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "BED")

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -1383,7 +1383,20 @@ facts("Sequence Parsing") do
             for seqrec in open(filename, FASTQ, memory_map=true)
             end
 
-            return true
+            # Check round trip
+            output = IOBuffer()
+            expected_entries = Any[]
+            for seqrec in open(filename, FASTQ)
+                write(output, seqrec)
+                push!(expected_entries, seqrec)
+            end
+
+            read_entries = Any[]
+            for seqrec in open(takebuf_array(output), FASTQ)
+                push!(read_entries, seqrec)
+            end
+
+            return expected_entries == read_entries
         end
 
         path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "FASTQ")

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -1339,17 +1339,35 @@ facts("Sequence Parsing") do
             for seqrec in open(filename, FASTA, memory_map=true)
             end
 
-            return true
+            # Check round trip
+            output = IOBuffer()
+            expected_entries = Any[]
+            for seqrec in open(filename, FASTA)
+                write(output, seqrec)
+                push!(expected_entries, seqrec)
+            end
+
+            read_entries = Any[]
+            for seqrec in open(takebuf_array(output), FASTA)
+                push!(read_entries, seqrec)
+            end
+
+            return expected_entries == read_entries
         end
 
         path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "FASTA")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             tags = specimen["tags"]
+            valid = get(specimen, "valid", true)
             # currently unsupported features
             if contains(tags, "gaps") || contains(tags, "comments") || contains(tags, "ambiguity")
                 continue
             end
-            @fact check_fasta_parse(joinpath(path, specimen["filename"])) --> true
+            if valid
+                @fact check_fasta_parse(joinpath(path, specimen["filename"])) --> true
+            else
+                @fact_throws check_fasta_parse(joinpath(path, specimen["filename"]))
+            end
         end
     end
 


### PR DESCRIPTION
This adds tests that reads examples, writes them, then reads them back. This tests that contents of what we are reading and writing is well-formed.

It also fixed a few things that were caught by these tests:
  * Amino acid sequences were missing two residues when read from fasta.
  * fasta and fastq files print trailing space when there is no description.
  * Solexa fastq quality scores (which can be negative) were not encoded correctly when written.