### PR TITLE
BAM Parser

### DIFF
--- a/src/BGZF.jl
+++ b/src/BGZF.jl
@@ -1,0 +1,162 @@
+
+module BGZF
+
+export BGZFSource
+
+using BufferedStreams
+using Libz
+
+import Base: eof, readbytes!
+
+
+# compressed and decompressed blocks are <= this in BGZF
+const BGZF_MAX_BLOCK_SIZE = Int(0x10000)
+
+
+"""
+General error thrown when data did not conform the BGZF standard.
+"""
+immutable MalformedBGZFData <: Exception
+end
+
+
+immutable BGZFSource{T <: IO}
+    input::T
+    zstream::Base.RefValue{Libz.ZStream}
+
+    # space to read the next compressed block
+    compressed_block::Vector{UInt8}
+
+    # space to decompress the block
+    decompressed_block::Vector{UInt8}
+
+    # number of bytes available in decompressed_block
+    bytes_available::Base.RefValue{Int}
+
+    # number of bytes from decompressed_block that have been consumed
+    bytes_consumed::Base.RefValue{Int}
+
+    # true if there are no more bytes to consume
+    eof::Base.RefValue{Bool}
+end
+
+
+function BGZFSource(input::IO)
+    zstream = Libz.init_inflate_zstream(true)
+    return BGZFSource(input, zstream, Array(UInt8, BGZF_MAX_BLOCK_SIZE),
+                      Array(UInt8, BGZF_MAX_BLOCK_SIZE), Ref(0), Ref(0), Ref(false))
+end
+
+
+function eof(source::BGZFSource)
+    return source.eof[]
+end
+
+
+"""
+Read the next compressed BGZF block into `output`.
+"""
+@inline function read_bgzf_block!(input::IO, output::Vector{UInt8})
+    # read header up to xlen
+    p = 1
+    id1 = output[p] = read(input, UInt8); p += 1
+    id2 = output[p] = read(input, UInt8); p += 1
+    cm  = output[p] = read(input, UInt8); p += 1
+    flg = output[p] = read(input, UInt8); p += 1
+
+    if id1 != 0x1f || id2 != 0x8b || cm != 0x08 || flg != 0x04
+        throw(MalformedBGZFData)
+    end
+
+    for _ in 1:8
+        output[p] = read(input, UInt8); p += 1
+    end
+
+    xlen = (Int(output[p - 1]) << 8) | Int(output[p - 2])
+    if xlen < 6
+        throw(MalformedBGZFData)
+    end
+
+    # read extra subfields
+    nb = readbytes!(
+        input, pointer_to_array(pointer(output, p), (length(output) - p + 1,)),
+        xlen)
+    if nb != xlen
+        throw(MalformedBGZFData)
+    end
+    bsize = (Int(output[p + 5]) << 8 | Int(output[p + 4]))
+    p += xlen
+
+    # read the rest of the bgzf block
+    remaining_block_size = bsize - xlen - 11
+    nb = readbytes!(
+        input, pointer_to_array(pointer(output, p), (length(output) - p + 1,)),
+        remaining_block_size)
+    p += nb
+    if nb != remaining_block_size
+        throw(MalformedBGZFData)
+    end
+
+    # size of uncompressed (input) data
+    isize = (Int(output[p - 1]) << 24) | (Int(output[p - 2]) << 16) |
+            (Int(output[p - 3]) << 8) | (Int(output[p - 4]))
+    return bsize + 1, isize
+end
+
+
+"""
+Decompress the next BGZF block into source.decompressed_block.
+"""
+function decompress_block(source::BGZFSource)
+    bsize, isize = read_bgzf_block!(source.input, source.compressed_block)
+
+    zstream = getindex(source.zstream)
+    zstream.next_out = pointer(source.decompressed_block)
+    zstream.avail_out = isize
+    zstream.next_in = pointer(source.compressed_block)
+    zstream.avail_in = bsize
+
+    ret = ccall((:inflate, Libz._zlib), Cint, (Ptr{Libz.ZStream}, Cint),
+                source.zstream, Libz.Z_FINISH)
+
+   if ret != Libz.Z_STREAM_END || zstream.avail_in != 0 || zstream.avail_out != 0
+       error("Failed to decompress a BGZF block (zlib error $(ret))")
+   end
+
+    ret = ccall((:inflateReset, Libz._zlib), Cint, (Ptr{Libz.ZStream},), source.zstream)
+    if ret != Libz.Z_OK
+        error("Unable to reset zlib stream.")
+    end
+
+    source.bytes_consumed[] = 0
+    source.bytes_available[] = isize
+end
+
+
+function readbytes!(source::BGZFSource, buffer::Vector{UInt8}, from::Int, to::Int)
+    from0 = from
+    while to - from + 1 > 0
+        available = source.bytes_available[] - source.bytes_consumed[]
+        nb = min(to - from + 1, available)
+        Base.unsafe_copy!(pointer(buffer, from),
+                          pointer(source.decompressed_block,
+                                  1 + source.bytes_consumed[]), nb)
+        from += nb
+        source.bytes_consumed[] += nb
+
+        if source.bytes_consumed[] == source.bytes_available[]
+            if eof(source.input)
+                source.eof[] = true
+                break
+            else
+                decompress_block(source)
+            end
+        end
+    end
+
+    return from - from0
+end
+
+
+end # module BGZF
+

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -7,7 +7,7 @@ include("BGZF.jl")
 include("StringFields.jl")
 include("Ragel.jl")
 include("seq/Seq.jl")
-include("align/Align.jl")
 include("intervals/Intervals.jl")
+include("align/Align.jl")
 
 end # module Bio

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -3,9 +3,11 @@ module Bio
 abstract AbstractParser
 abstract FileFormat
 
+include("BGZF.jl")
 include("StringFields.jl")
 include("Ragel.jl")
 include("seq/Seq.jl")
+include("align/Align.jl")
 include("intervals/Intervals.jl")
 
 end # module Bio

--- a/src/Ragel.jl
+++ b/src/Ragel.jl
@@ -256,32 +256,26 @@ end
 # ----------------------------------
 
 function open{T <: FileFormat}(filename::AbstractString, ::Type{T}; args...)
-    memory_map = false
-    i = 0
-    for arg in args
-        i += 1
-        if arg[1] == :memory_map
-            memory_map = arg[2]
-            break
-        end
-    end
-    if i > 0
-        splice!(args, i)
-    end
-
-    if memory_map
-        source = Mmap.mmap(open(filename), Vector{UInt8}, (filesize(filename),))
-    else
-        source = open(filename)
-    end
-
+    source = open(filename)
     stream = BufferedInputStream(source)
     open(stream, T; args...)
 end
 
 
+function open{T <: FileFormat}(filename::AbstractString, ::Type{T})
+    source = open(filename)
+    stream = BufferedInputStream(source)
+    open(stream, T)
+end
+
+
 function open{T <: FileFormat}(source::Union{IO, Vector{UInt8}}, ::Type{T}; args...)
     open(BufferedInputStream(source), T; args...)
+end
+
+
+function open{T <: FileFormat}(source::Union(IO, Vector{UInt8}), ::Type{T})
+    open(BufferedInputStream(source), T)
 end
 
 

--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -85,11 +85,11 @@ end
 
 function copy!(field::StringField, data::Vector{UInt8},
                start::Integer, stop::Integer)
-    if length(field.data) < length(data)
+    n = stop - start + 1
+    if length(field.data) < n
         resize!(field.data, length(data))
     end
-    n = stop - start + 1
-    copy!(field.data, 1, data, start, n)
+    unsafe_copy!(field.data, 1, data, start, n)
     field.part = 1:n
     return n
 end
@@ -102,6 +102,10 @@ end
 
 function isempty(field::StringField)
     return field.part.start > field.part.stop
+end
+
+function convert(::Type{StringField}, str::StringField)
+    return str
 end
 
 

--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -11,6 +11,7 @@ import Base:
     copy,
     empty!,
     endof,
+    getindex,
     hash,
     isempty,
     isvalid,
@@ -83,11 +84,11 @@ function next(s::StringField, i::Int)
 end
 
 
-function copy!(field::StringField, data::Vector{UInt8},
-               start::Integer, stop::Integer)
+@inline function copy!(field::StringField, data::Vector{UInt8},
+                       start::Integer, stop::Integer)
     n = stop - start + 1
     if length(field.data) < n
-        resize!(field.data, length(data))
+        resize!(field.data, n)
     end
     unsafe_copy!(field.data, 1, data, start, n)
     field.part = 1:n
@@ -175,6 +176,15 @@ function (==)(a::StringField, b::BufferedStreams.BufferedOutputStream)
     else
         return false
     end
+end
+
+
+function getindex(field::StringField, r::UnitRange{Int})
+    r = (field.part.start + r.start - 1):(field.part.start + r.stop - 1)
+    if r.stop > field.part.stop
+        throw(BoundsError)
+    end
+    return StringField(field.data, r)
 end
 
 

--- a/src/align/Align.jl
+++ b/src/align/Align.jl
@@ -1,0 +1,10 @@
+
+module Align
+
+using Bio: AbstractParser, FileFormat
+
+export BAM
+
+include("bam.jl")
+
+end

--- a/src/align/bam.jl
+++ b/src/align/bam.jl
@@ -1,0 +1,145 @@
+
+using Libz
+using BufferedStreams
+
+using Bio.Seq
+using Bio.BGZF
+using Bio.StringFields
+
+immutable BAM <: FileFormat end
+
+
+# TODO: This is a temporary type. We should find a more general alignment
+# representation
+type BAMAlignment
+    refname::StringField
+    position::Int64
+    mapq::UInt8
+    bin::UInt16
+    flag::UInt16
+    next_refname::StringField
+    next_pos::Int64
+    tlen::Int32
+    read_name::StringField
+    cigar::StringField # TODO: a more specialized structure
+    seq::DNASequence
+    qual::Vector{UInt8}
+    # TODO
+    #aux::
+end
+
+
+function BAMAlignment()
+    return BAMAlignment(StringField(), -1, 0, 0, 0, StringField(), -1, -1,
+                        StringField(), StringField(), DNASequence(), UInt8[])
+end
+
+
+immutable BAMParser{T <: BufferedInputStream} <: AbstractParser
+    stream::T
+    header_text::StringField
+    refs::Vector{Tuple{StringField, Int}}
+
+    # TODO: Store header somewhere?
+end
+
+
+@inline function unsafe_load_type(buffer::Vector{UInt8}, position::Integer, T::Type)
+    return unsafe_load(convert(Ptr{T}, pointer(buffer, position)))
+end
+
+
+function Base.open(source_stream::BufferedInputStream, ::Type{BAM})
+    #bgzf_source = BGZFSource(source_stream)
+    #stream = BufferedInputStream(bgzf_source)
+    stream = BufferedInputStream(BGZFSource(source_stream))
+    #stream = ZlibInflateInputStream(source_stream)
+
+    buffer = stream.buffer
+
+    # magic bytes
+    anchor!(stream)
+    seekforward(stream, 4)
+    p = upanchor!(stream)
+    if !(buffer[p]     == UInt8('B') &&
+         buffer[p + 1] == UInt8('A') &&
+         buffer[p + 2] == UInt8('M') &&
+         buffer[p + 3] == 0x01)
+        error("Input was not a valid BAM file. (Nonmatching magic bytes.)")
+    end
+
+    # header size
+    anchor!(stream)
+    seekforward(stream, 4)
+    header_size = unsafe_load_type(buffer, upanchor!(stream), Int32)
+
+    # header
+    anchor!(stream)
+    seekforward(stream, header_size)
+    header_text = StringField(takeanchored!(stream))
+    upanchor!(stream)
+
+    # number of reference sequences
+    anchor!(stream)
+    seekforward(stream, 4)
+    numrefs = unsafe_load_type(buffer, upanchor!(stream), Int32)
+
+    # reference sequence names and sizes
+    refs = Array(Tuple{StringField, Int}, numrefs)
+    for i in 1:numrefs
+        anchor!(stream)
+        seekforward(stream, 4)
+        name_length = unsafe_load_type(buffer, upanchor!(stream), Int32)
+
+        anchor!(stream)
+        seekforward(stream, name_length)
+        name = StringField(takeanchored!(stream))
+
+        anchor!(stream)
+        seekforward(stream, 4)
+        seq_size = unsafe_load_type(buffer, upanchor!(stream), Int32)
+        refs[i] = (name, seq_size)
+    end
+
+    return BAMParser(stream, header_text, refs)
+end
+
+
+#function Base.read!(parser::BAMParser, align::BAMAlignment)
+    #stream = parser.stream # 0.05
+    #if eof(stream)
+        #return false
+    #end
+
+    ##block_size = read(stream, Int32) # 0.25
+
+    #anchor!(stream)
+    #seekforward(stream, 4)
+    #block_size = unsafe_load_type(stream.buffer, upanchor!(stream), Int32)
+
+    ### read the entire entry into the buffer
+    #anchor!(stream)
+    #seekforward(stream, block_size) # 0.62
+    #p = upanchor!(stream)
+
+    #return true
+#end
+
+
+# Maybe if we read a bunch of things at once?
+function Base.read!(parser::BAMParser, align::BAMAlignment)
+    stream = parser.stream
+    while !eof(stream)
+        anchor!(stream)
+        seekforward(stream, 4)
+        block_size = unsafe_load_type(stream.buffer, upanchor!(stream), Int32)
+
+        anchor!(stream)
+        seekforward(stream, block_size)
+        p = upanchor!(stream)
+    end
+
+    return false
+end
+
+

--- a/src/align/bam.jl
+++ b/src/align/bam.jl
@@ -24,14 +24,27 @@ type BAMAlignment
     cigar::StringField # TODO: a more specialized structure
     seq::DNASequence
     qual::Vector{UInt8}
-    # TODO
-    #aux::
+    aux::StringField # TODO: a more specialized structure
 end
 
 
 function BAMAlignment()
     return BAMAlignment(StringField(), -1, 0, 0, 0, StringField(), -1, -1,
-                        StringField(), StringField(), DNASequence(), UInt8[])
+                        StringField(), StringField(), DNASequence(), UInt8[],
+                        StringField())
+end
+
+
+# Leading size parts of a bam entry
+immutable BAMEntryHead
+    refid::Int32
+    pos::Int32
+    bin_mq_nl::UInt32
+    flag_nc::UInt32
+    l_seq::Int32
+    next_refid::Int32
+    next_pos::Int32
+    tlen::Int32
 end
 
 
@@ -39,8 +52,6 @@ immutable BAMParser{T <: BufferedInputStream} <: AbstractParser
     stream::T
     header_text::StringField
     refs::Vector{Tuple{StringField, Int}}
-
-    # TODO: Store header somewhere?
 end
 
 
@@ -49,11 +60,8 @@ end
 end
 
 
-function Base.open(source_stream::BufferedInputStream, ::Type{BAM})
-    #bgzf_source = BGZFSource(source_stream)
-    #stream = BufferedInputStream(bgzf_source)
+function Base.open{T <: BufferedInputStream}(source_stream::T, ::Type{BAM})
     stream = BufferedInputStream(BGZFSource(source_stream))
-    #stream = ZlibInflateInputStream(source_stream)
 
     buffer = stream.buffer
 
@@ -101,49 +109,69 @@ function Base.open(source_stream::BufferedInputStream, ::Type{BAM})
         refs[i] = (name, seq_size)
     end
 
-    return BAMParser(stream, header_text, refs)
+    return BAMParser{BufferedInputStream{BGZFSource{T}}}(stream, header_text, refs)
 end
 
 
-#function Base.read!(parser::BAMParser, align::BAMAlignment)
-    #stream = parser.stream # 0.05
-    #if eof(stream)
-        #return false
-    #end
-
-    ##block_size = read(stream, Int32) # 0.25
-
-    #anchor!(stream)
-    #seekforward(stream, 4)
-    #block_size = unsafe_load_type(stream.buffer, upanchor!(stream), Int32)
-
-    ### read the entire entry into the buffer
-    #anchor!(stream)
-    #seekforward(stream, block_size) # 0.62
-    #p = upanchor!(stream)
-
-    #return true
-#end
-
-
-# Maybe if we read a bunch of things at once?
-function Base.read!(parser::BAMParser, align::BAMAlignment)
+function Base.read!(parser::BAMParser, alignment::BAMAlignment)
     stream = parser.stream
-    n = 0
-    while !eof(stream)
-        n += 1
-        #block_size = read(stream, Int32)
-        anchor!(stream)
-        seekforward(stream, 4)
-        block_size = unsafe_load_type(stream.buffer, upanchor!(stream), Int32)
-
-        anchor!(stream)
-        seekforward(stream, block_size)
-        p = upanchor!(stream)
+    if eof(stream)
+        return false
     end
-    @show n
 
-    return false
+    # read the entire entry into the buffer
+    block_size = read(stream, Int32)
+    anchor!(stream)
+    seekforward(stream, block_size)
+    p = upanchor!(stream)
+
+    # extract fields
+    ptr = pointer(stream.buffer, p)
+    fields = unsafe_load(convert(Ptr{BAMEntryHead}, ptr))
+    if fields.refid >= 0
+        alignment.refname = parser.refs[fields.refid + 1][1]
+    else
+        empty!(alignment.refname)
+    end
+
+    alignment.position = fields.pos + 1 # make 1-based
+    l_read_name = fields.bin_mq_nl & 0xf
+    alignment.mapq = (fields.bin_mq_nl >> 8) & 0xf
+    alignment.bin = (fields.bin_mq_nl >> 16) & 0xff
+    n_cigar_op = fields.flag_nc & 0xff
+    alignment.flag = fields.flag_nc >> 16
+
+    if fields.next_refid >= 0
+        alignment.next_refname = parser.refs[fields.next_refid + 1][1]
+    else
+        empty!(alignment.next_refname)
+    end
+
+    alignment.next_pos = fields.next_pos
+    alignment.tlen = fields.tlen
+
+    p += sizeof(BAMEntryHead)
+    copy!(alignment.read_name, stream.buffer, p, p + l_read_name - 1)
+
+    p += l_read_name
+    copy!(alignment.cigar, stream.buffer, p, p + n_cigar_op * 4 - 1)
+
+    # TODO: BAM 4-bit encodes a DNA sequence. We need to write a special
+    # conversion function.
+    p += n_cigar_op * 4
+    #copy!(alignment.seq, stream.buffer, p, p + fields.l_seq - 1)
+
+    p += div(fields.l_seq + 1, 2)
+    if length(alignment.qual) != fields.l_seq
+        resize!(alignment.qual, fields.l_seq)
+    end
+    copy!(alignment.qual, 1, stream.buffer, p, fields.l_seq)
+
+    p += fields.l_seq
+    copy!(alignment.aux, stream.buffer, p, stream.position - 1)
+
+    return true
 end
+
 
 

--- a/src/align/bam.jl
+++ b/src/align/bam.jl
@@ -3,35 +3,252 @@ using Libz
 using BufferedStreams
 
 using Bio.Seq
+using Bio.Seq: DNA_INVALID
 using Bio.BGZF
 using Bio.StringFields
+using Bio.Intervals
+using IntervalTrees
 
 immutable BAM <: FileFormat end
 
+# OK, let's really think about how we want to represent BAM.
+#
+# Maybe I should just store the second half of the BAM file in one StringField
+# buffer, then manifest the other fields as needed. Should they be cached?
 
 # TODO: This is a temporary type. We should find a more general alignment
 # representation
-type BAMAlignment
-    refname::StringField
+type BAMAlignment <: AbstractInterval{Int64}
+    seqname::StringField
     position::Int64
     mapq::UInt8
     bin::UInt16
     flag::UInt16
-    next_refname::StringField
+    next_seqname::StringField
     next_pos::Int64
     tlen::Int32
-    read_name::StringField
-    cigar::StringField # TODO: a more specialized structure
-    seq::DNASequence
-    qual::Vector{UInt8}
-    aux::StringField # TODO: a more specialized structure
+
+    # variable length data: read name, cigar data, sequence, quality scores, and aux
+    # offsets within the data
+    data::StringField
+    cigar_position::Int32
+    seq_position::Int32
+    seq_length::Int32
+    qual_position::Int32
+    aux_position::Int32
+end
+
+
+# Interval interface
+function first(bam::BAMAlignment)
+    return bam.position
+end
+
+
+function last(bam::BAMAlignment)
+    # TODO: calculate end
+end
+
+
+"""
+Return a `StringField` containing the read name. This becomes invalidated if
+the `BAMAlignment` is overwritten.
+"""
+function readname(bam::BAMAlignment)
+    bam.data[1:bam.cigar_position-1]
+end
+
+
+"""
+Copy the read's name into `name`.
+"""
+function readname!(bam::BAMAlignment, name::StringField)
+    copy!(name, bam.data, 1, bam.cigar_position-1)
+end
+
+
+function cigar(bam::BAMAlignment)
+    # TODO
+end
+
+
+const bam4bit_to_char = [
+    '=', 'A', 'C', 'M', 'G', 'R', 'S', 'V', 'T', 'W', 'Y', 'H', 'K', 'D', 'B', 'N' ]
+
+const bam4bit_to_dna = [
+    DNA_INVALID, DNA_A,       DNA_C,       DNA_INVALID,
+    DNA_G,       DNA_INVALID, DNA_INVALID, DNA_INVALID,
+    DNA_T,       DNA_INVALID, DNA_INVALID, DNA_INVALID,
+    DNA_INVALID, DNA_INVALID, DNA_INVALID, DNA_N ]
+
+
+"""
+Return a DNASequence throwing an error if the sequence contains characters other
+than A, C, G, T, N.
+"""
+function sequence(bam::BAMAlignment)
+    # This follows closely from @encode_seq, but unfortunately not enough to
+    # reuse that.
+    seq_length = bam.seq_length
+    seqdata = zeros(UInt64, Seq.seq_data_len(seq_length))
+    ns = falses(Int(seq_length))
+    recode_bam_sequence!(bam.data.data, bam.seq_position, bam.seq_length, seqdata, ns)
+    return DNASequence(seqdata, ns, 1:seq_length, false, false)
+end
+
+
+function sequence!(bam::BAMAlignment, seq::DNASequence)
+    if !seq.mutable
+        error("Cannot copy sequence from BAMAlignment to immutable DNASequence. Call `mutable!(seq)` first.")
+    end
+
+    len = Seq.seq_data_len(bam.seq_length)
+    if length(seq.data) < len
+        resize!(seq.data, len)
+    end
+
+    if length(seq.ns) < bam.seq_length
+        resize!(seq.ns, n)
+    end
+
+    fill!(seq.data, 0)
+    fill!(seq.ns, false)
+    seq.part = 1:bam.seq_length
+
+    recode_bam_sequence!(bam.data.data, bam.seq_position, bam.seq_length, seq.data, seq.ns)
+
+    return seq
+end
+
+
+# Recode a BAM sequence from 4-bit to 2-bit.
+function recode_bam_sequence!(input::Vector{UInt8}, seq_position::Integer,
+                              seq_length::Integer, seqdata::Vector{UInt64}, ns::BitVector)
+    len = Seq.seq_data_len(seq_length)
+    ored_nucs = UInt8(0)
+    j = seq_position
+    idx = 1
+    for i in 1:len
+        shift = 0
+        data_i = UInt64(0)
+        while shift < 64
+            if idx > seq_length
+                break
+            end
+
+            # high nibble
+            @inbounds nt = bam4bit_to_dna[1 + (input[j] >>> 4)]
+            if nt == DNA_N
+                d = (idx - 1) >>> 6
+                r = (idx - 1) & 63
+                ns.chunks[d + 1] |= UInt64(1) << r
+            else
+                ored_nucs |= convert(UInt8, nt)
+                data_i |= convert(UInt64, nt) << shift
+            end
+
+            shift += 2
+            idx += 1
+
+            if idx > seq_length
+                break
+            end
+
+            # low nibble
+            @inbounds nt = bam4bit_to_dna[1 + (input[j] & 0xf)]
+            if nt == DNA_N
+                d = (idx - 1) >>> 6
+                r = (idx - 1) & 63
+                ns.chunks[d + 1] |= UInt64(1) << r
+            else
+                ored_nucs |= convert(UInt8, nt)
+                data_i |= convert(UInt64, nt) << shift
+            end
+
+            shift += 2
+            idx += 1
+            j += 1
+        end
+        @inbounds seqdata[i] = data_i
+    end
+
+    # if there was a bad nucleotide, go back and find it
+    if ored_nucs & 0b1000 != 0
+        idx = 1
+        j = seq_position
+        while true
+            if idx > seq_length
+                break
+            end
+
+            # high nibble
+            nt = bam4bit_to_dna[1 + (input[j] >>> 4)]
+            if nt == DNA_INVALID
+                error(string(bam4bit_to_char[1 + (input[j] >>> 4)], " is not a valid DNA nucleotide."))
+            end
+            idx += 1
+
+            if idx > seq_length
+                break
+            end
+
+            # low nibble
+            nt = bam4bit_to_dna[1 + (input[j] & 0xf)]
+            if nt == DNA_INVALID
+                error(string(bam4bit_to_char[1 + (input[j] & 0xf)], " is not a valid DNA nucleotide."))
+            end
+            idx += 1
+            j += 1
+        end
+    end
+end
+
+
+function qualities(bam::BAMAlignment)
+    r = bam.qual_position:bam.aux_position-1
+    qs = Array(Int8, length(r))
+    for (i, j) in enumerate(r)
+        @inbounds qs[i] = bam.data.data[j] - 33
+    end
+    return qs
+end
+
+
+function qualities!(bam::BAMAlignment, qs::Vector{Int8})
+    r = bam.qual_position:bam.aux_position-1
+    if length(qs) != length(r)
+        resize!(qs, length(r))
+    end
+    for (i, j) in enumerate(r)
+        @inbounds qs[i] = bam.data.data[j] - 33
+    end
+    return qs
+end
+
+
+# Return all auxillary data
+function auxiliary(bam::BAMAlignment)
+    # TODO
+end
+
+
+# Return a specific tag
+function auxillary(bam::BAMAlignment, t1::Char, t2::Char)
+    # TODO
+end
+
+
+function auxillary(bam::BAMAlignment, tag::AbstractString)
+    if length(tag) != 2
+        error("BAM auxillary data tags must be of length 2")
+    end
+    return auxillary(bam, tag[1], tag[2])
 end
 
 
 function BAMAlignment()
     return BAMAlignment(StringField(), -1, 0, 0, 0, StringField(), -1, -1,
-                        StringField(), StringField(), DNASequence(), UInt8[],
-                        StringField())
+                        StringField(), -1, -1, -1, -1, -1)
 end
 
 
@@ -128,47 +345,36 @@ function Base.read!(parser::BAMParser, alignment::BAMAlignment)
     # extract fields
     ptr = pointer(stream.buffer, p)
     fields = unsafe_load(convert(Ptr{BAMEntryHead}, ptr))
-    if fields.refid >= 0
-        alignment.refname = parser.refs[fields.refid + 1][1]
+    if 0 <= fields.refid < length(parser.refs)
+        @inbounds alignment.seqname = parser.refs[fields.refid + 1][1]
     else
-        empty!(alignment.refname)
+        empty!(alignment.seqname)
     end
 
     alignment.position = fields.pos + 1 # make 1-based
-    l_read_name = fields.bin_mq_nl & 0xf
-    alignment.mapq = (fields.bin_mq_nl >> 8) & 0xf
-    alignment.bin = (fields.bin_mq_nl >> 16) & 0xff
+    l_read_name = fields.bin_mq_nl & 0xff
+    alignment.mapq = (fields.bin_mq_nl >> 8) & 0xff
+    alignment.bin = (fields.bin_mq_nl >> 16) & 0xffff
     n_cigar_op = fields.flag_nc & 0xff
     alignment.flag = fields.flag_nc >> 16
 
-    if fields.next_refid >= 0
-        alignment.next_refname = parser.refs[fields.next_refid + 1][1]
+    if 0 <= fields.next_refid < length(parser.refs)
+        @inbounds alignment.next_seqname = parser.refs[fields.next_refid + 1][1]
     else
-        empty!(alignment.next_refname)
+        empty!(alignment.next_seqname)
     end
 
     alignment.next_pos = fields.next_pos
     alignment.tlen = fields.tlen
 
     p += sizeof(BAMEntryHead)
-    copy!(alignment.read_name, stream.buffer, p, p + l_read_name - 1)
+    copy!(alignment.data, stream.buffer, p, stream.position - 1)
 
-    p += l_read_name
-    copy!(alignment.cigar, stream.buffer, p, p + n_cigar_op * 4 - 1)
-
-    # TODO: BAM 4-bit encodes a DNA sequence. We need to write a special
-    # conversion function.
-    p += n_cigar_op * 4
-    #copy!(alignment.seq, stream.buffer, p, p + fields.l_seq - 1)
-
-    p += div(fields.l_seq + 1, 2)
-    if length(alignment.qual) != fields.l_seq
-        resize!(alignment.qual, fields.l_seq)
-    end
-    copy!(alignment.qual, 1, stream.buffer, p, fields.l_seq)
-
-    p += fields.l_seq
-    copy!(alignment.aux, stream.buffer, p, stream.position - 1)
+    alignment.cigar_position = l_read_name + 1
+    alignment.seq_position = alignment.cigar_position + n_cigar_op * sizeof(Int32)
+    alignment.seq_length = fields.l_seq
+    alignment.qual_position = alignment.seq_position + div(fields.l_seq + 1, 2)
+    alignment.aux_position = alignment.qual_position + fields.l_seq
 
     return true
 end

--- a/src/align/bam.jl
+++ b/src/align/bam.jl
@@ -129,7 +129,10 @@ end
 # Maybe if we read a bunch of things at once?
 function Base.read!(parser::BAMParser, align::BAMAlignment)
     stream = parser.stream
+    n = 0
     while !eof(stream)
+        n += 1
+        #block_size = read(stream, Int32)
         anchor!(stream)
         seekforward(stream, 4)
         block_size = unsafe_load_type(stream.buffer, upanchor!(stream), Int32)
@@ -138,6 +141,7 @@ function Base.read!(parser::BAMParser, align::BAMAlignment)
         seekforward(stream, block_size)
         p = upanchor!(stream)
     end
+    @show n
 
     return false
 end

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -362,7 +362,7 @@ Reset the contents of a mutable sequence from a string.
 function copy!{T}(seq::NucleotideSequence{T}, strdata::Vector{UInt8},
                   startpos::Integer, stoppos::Integer)
     if !seq.mutable
-        error("Cannot copy! to immutable sequnce. Call `mutable!(seq)` first.")
+        error("Cannot copy! to immutable sequence. Call `mutable!(seq)` first.")
     end
 
     n = stoppos - startpos + 1


### PR DESCRIPTION
This is my work in progress on a BAM parser. <del>It's currently about 10% slower than the one in htslib, but will probably be at parity with a little tweaking.</del> Performance is now indistinguishable from htslib/samtools, but with much simpler code.

TODO:
  <del>* [ ] Data structure to read sequence into: I thought I would just use `DNASequence`, but I need to figure out what to do with `*` and `=` in the sequence field.</del>
  <del>* [ ] Data structure to read cigar strings into.</del>
  <del>* [ ] Data structure to read auxiliary data into.</del>
  * [x] `readname(::BAMAlignment)`
  * [x] `qualities(::BAMAlignment)` and `qualities!(::BAMAlignment, ::Vector{Int8})` to extract qualities.
  * [x] `sequence(::BAMAlignment)` and `sequence!(::BAMAlignment, ::DNASequence)` to extract sequences.
  * [ ] `last(::BAMAlignment)` so alignments can be treated as intervals.
  * [ ] `cigar(::BAMAlignment)`
  * [x] `auxiliary(::BAMAlignment)` and `auxiliary(::BAMAlignment, tag)`.
  * [ ] Iteration for `BAMParser`
  * Write BAM
    * [ ] BGZF output stream
    * [ ] `write(::BAMWriter, ::BAMAlignment)`
  * Tests.
    * [ ] Harvest test cases for BioFmtSpecimens
    * [ ] Round trip tests.

I ended up not using ragel. Parsing BAM is mostly reading fixed sized fields: there's very little matching involved, just counting bytes for which ragel isn't much of a help. SAM will use ragel, but BAM is more important, so that will be another PR.