### PR TITLE
import hash from Base

### DIFF
--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -105,6 +105,7 @@ import Base:
     eltype,
     getindex,
     setindex!,
+    hash,
     ==,
     *,
     ^,


### PR DESCRIPTION
I'm inclined believe that appending the `Base.` prefix is a better solution (ref: #96).