### PR TITLE
fix firstref and lastref

### DIFF
--- a/src/align/anchors.jl
+++ b/src/align/anchors.jl
@@ -78,7 +78,8 @@ immutable Alignment
         firstref = 0
         for i in 1:length(anchors)
             if ismatchop(anchors[i].op)
-                firstref = anchors[i-1].refpos
+                firstref = anchors[i-1].refpos + 1
+                break
             end
         end
 
@@ -86,6 +87,7 @@ immutable Alignment
         for i in length(anchors):-1:1
             if ismatchop(anchors[i].op)
                 lastref = anchors[i].refpos
+                break
             end
         end
 

--- a/test/align/TestAlign.jl
+++ b/test/align/TestAlign.jl
@@ -154,6 +154,29 @@ facts("Alignments") do
                             aln.anchors[1].refpos + 1) --> aln
         end
     end
+
+    context("AlignedSequence") do
+        #               0   4        9  12 15     19
+        #               |   |        |  |  |      |
+        #     query:     TGGC----ATCATTTAACG---CAAG
+        # reference: AGGGTGGCATTTATCAG---ACGTTTCGAGAC
+        #               |   |   |    |     |  |   |
+        #               4   8   12   17    20 23  27
+        anchors = [
+            AlignmentAnchor(0, 4, OP_START),
+            AlignmentAnchor(4, 8, OP_MATCH),
+            AlignmentAnchor(4, 12, OP_DELETE),
+            AlignmentAnchor(9, 17, OP_MATCH),
+            AlignmentAnchor(12, 17, OP_INSERT),
+            AlignmentAnchor(15, 20, OP_MATCH),
+            AlignmentAnchor(15, 23, OP_DELETE),
+            AlignmentAnchor(19, 27, OP_MATCH)
+        ]
+        query = "TGGCATCATTTAACGCAAG"
+        alnseq = AlignedSequence(query, anchors)
+        @fact Bio.Align.first(alnseq) --> 5
+        @fact Bio.Align.last(alnseq) --> 27
+    end
 end
 
 end # TestAlign


### PR DESCRIPTION
If I read [this comment] (https://github.com/BioJulia/Bio.jl/blob/93a83c11edcff057849ea84e41d5aa82ce308131/src/align/anchors.jl#L77-Lundefined) correctly, this would be the intended behavior.

