### PR TITLE
Sliding windows - redux

### DIFF
--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -6,6 +6,7 @@ abstract FileFormat
 include("StringFields.jl")
 include("Ragel.jl")
 include("seq/Seq.jl")
+include("util/Util.jl")
 include("intervals/Intervals.jl")
 include("align/Align.jl")
 

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -91,6 +91,7 @@ import Base:
     complement,
     show,
     length,
+    sub,
     start,
     next,
     done,

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -233,6 +233,8 @@ function AminoAcidSequence(other::AminoAcidSequence, part::UnitRange;
     return seq
 end
 
+"Construct a subsequence of another amino acid sequence"
+sub(seq::AminoAcidSequence, r::UnitRange) = AminoAcidSequence(seq, r)
 
 "Construct of a subsequence from another amino acid sequence"
 function AminoAcidSequence(seq::Union{Vector{UInt8}, AbstractString},

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -689,6 +689,7 @@ end
 # Construct a subesequence
 getindex{T}(seq::NucleotideSequence{T}, r::UnitRange) = NucleotideSequence{T}(seq, r)
 
+sub{T}(seq::NucleotideSequence{T}, r::UnitRange) = NucleotideSequence{T}(seq, r)
 
 function setindex!{T}(seq::NucleotideSequence{T}, nt::T, i::Integer)
     if !seq.mutable

--- a/src/util/Util.jl
+++ b/src/util/Util.jl
@@ -1,0 +1,12 @@
+module Util
+
+import Base:
+    start,
+    next,
+    done
+
+export eachwindow
+
+include("windows.jl")
+
+end # module Util

--- a/src/util/Util.jl
+++ b/src/util/Util.jl
@@ -3,9 +3,11 @@ module Util
 import Base:
     start,
     next,
-    done
+    done,
+    show
 
-export eachwindow
+export eachwindow,
+    EachWindowIterator
 
 include("windows.jl")
 

--- a/src/util/Util.jl
+++ b/src/util/Util.jl
@@ -6,6 +6,9 @@ import Base:
     done,
     show
 
+import Bio.Seq:
+    Sequence
+
 export eachwindow,
     EachWindowIterator
 

--- a/src/util/Util.jl
+++ b/src/util/Util.jl
@@ -4,13 +4,16 @@ import Base:
     start,
     next,
     done,
-    show
+    show,
+    size,
+    ==
 
-import Bio.Seq:
+using Bio.Seq:
     Sequence
 
 export eachwindow,
-    EachWindowIterator
+    EachWindowIterator,
+    missed
 
 include("windows.jl")
 

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,0 +1,41 @@
+import Base:
+    start,
+    next,
+    done
+
+# Iterate through every window in type
+immutable EachWindowIterator{T}
+    vec::Vector{T}
+    K::Int
+    step::Int
+    npos::Int  # Number of windows, length(vec) - K + step
+
+    EachWindowIterator(vec, K, step=1) = new(vec, K, step, length(vec) - K + 1)
+end
+
+immutable EachWindowIteratorState{T}
+    i::Int  # start position of current window
+end
+
+function eachwindow{T}(K::Integer, vec::Vector{T}, step::Integer=1)
+    @assert K >= 0 "K (window size) must be ≥ 0 in EachWindow"
+    @assert step >= 1 "step must be ≥ 1"
+
+    return EachWindowIterator{T}(vec, K, step)
+end
+
+function start{T}(it::EachWindowIterator{T})
+    i = 1
+    npos = length(it.vec) - it.K + it.step
+    return i
+end
+
+function next{T}(it::EachWindowIterator{T}, state::Integer)
+    i = state
+    value = sub(it.vec, i:i+it.K - 1)
+    return value, i + it.step
+end
+
+function done{T}(it::EachWindowIterator{T}, state::Integer)
+    return state > it.npos
+end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -15,7 +15,7 @@ immutable EachWindowIterator{T <: arrayOrStringOrSeq}
     function EachWindowIterator{T}(data::T, width::Int, step::Int = 1)
         @assert width >= 1 "Window width must be ≥ 1."
         @assert step >= 1 "step must be ≥ 1."
-        @assert width < length(data) "The window size cannot be greater than number of data elements."
+        @assert width <= length(data) "The window size cannot be greater than number of data elements."
         return new(data, width, step)
     end
 end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -58,6 +58,16 @@ end
     return window, i + it.step
 end
 
+# Extra next method to account for fact than strings don't have sub method
+# like arrays and Nucleotide sequences do.
+# The operation is an indexing operation, rather than a "proper"
+# substring or subarray operation.
+@inline function next{T <: AbstractString}(it::EachWindowIterator{T}, state::Integer)
+    i = state
+    window = it.data[i:i + it.width - 1]
+    return window
+end
+
 @inline function done(it::EachWindowIterator, state::Integer)
     return (state + it.width - 1) > length(it.data)
 end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -8,7 +8,7 @@ An iterator which moves across a container, as a sliding window.
 Constructor requires the data to move the window across, the width of the
 window, and the step of the window.
 """
-immutable EachWindowIterator{T <: arrayOrStringOrSeq}
+immutable EachWindowIterator{T <: ArrayOrStringOrSeq}
     "A reference to the collection to iterate over."
     data::T
     "The width of the sliding window."
@@ -56,7 +56,7 @@ Convienient function for constructing an EachWindowIterator.
 
 Accepts the same arguments as the EachWindowIterator constructor.
 """
-function eachwindow{T <: arrayOrStringOrSeq}(data::T, width::Int, step::Int = 1)
+function eachwindow{T <: ArrayOrStringOrSeq}(data::T, width::Int, step::Int = 1)
     EachWindowIterator{T}(data, width, step)
 end
 

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -19,18 +19,18 @@ function eachwindow{T}(K::Integer, vec::Vector{T}, step::Integer=1)
     return EachWindowIterator{T}(vec, K, step)
 end
 
-function start{T}(it::EachWindowIterator{T})
+@inline function start{T}(it::EachWindowIterator{T})
     i = 1
     npos = length(it.vec) - it.K + it.step
     return i
 end
 
-function next{T}(it::EachWindowIterator{T}, state::Integer)
+@inline function next{T}(it::EachWindowIterator{T}, state::Integer)
     i = state
     window = sub(it.vec, i:i+it.K - 1)
     return window, i + it.step
 end
 
-function done{T}(it::EachWindowIterator{T}, state::Integer)
+@inline function done{T}(it::EachWindowIterator{T}, state::Integer)
     return state > it.npos
 end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,4 +1,10 @@
-# Iterate through every window of size K in vec
+
+import Base:
+    start,
+    next,
+    done
+
+
 immutable EachWindowIterator{T}
     vec::Vector{T}
     K::Int
@@ -19,11 +25,11 @@ function eachwindow{T}(K::Integer, vec::Vector{T}, step::Integer=1)
     return EachWindowIterator{T}(vec, K, step)
 end
 
-@inline function start{T}(it::EachWindowIterator{T})
-    i = 1
-    npos = length(it.vec) - it.K + it.step
-    return i
+
+@inline function start(it::EachWindowIterator)
+    return 1
 end
+
 
 @inline function next{T}(it::EachWindowIterator{T}, state::Integer)
     i = state

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,5 +1,5 @@
 
-arrayOrStringOrSeq = Union{AbstractArray, AbstractString, Sequence}
+typealias ArrayOrStringOrSeq Union{AbstractArray, AbstractString, Sequence}
 
 
 """

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -44,8 +44,8 @@ Convienient function for constructing an EachWindowIterator.
 
 Accepts the same arguments as the EachWindowIterator constructor.
 """
-function eachwindow{T <: arrayOrStringOrSeq}(data::T, width::Integer, step::Integer = 1)
-    EachWindowIterator(data, width, step)
+function eachwindow{T <: arrayOrStringOrSeq}(data::T, width::Int, step::Int = 1)
+    EachWindowIterator{T}(data, width, step)
 end
 
 @inline function start(it::EachWindowIterator)

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -4,6 +4,9 @@ arrayOrStringOrSeq = Union{AbstractArray, AbstractString, Sequence}
 
 """
 An iterator which moves across a container, as a sliding window.
+
+Constructor requires the data to move the window across, the width of the
+window, and the step of the window.
 """
 immutable EachWindowIterator{T <: arrayOrStringOrSeq}
     "A reference to the collection to iterate over."
@@ -36,7 +39,16 @@ container are missed if window sizes and step sizes are too large.
 """
 function missed(winitr::EachWindowIterator)
     l = length(winitr.data)
-    return l - StepRange(winitr.width, winitr.step, l)
+    return l - StepRange(winitr.width, winitr.step, l).stop
+end
+
+"""
+A sliding window iterator is considered equal to another
+sliding window iterator if the data is considered equal, and the
+width and step of the iterator is also equivalent.
+"""
+function ==(x::EachWindowIterator, y::EachWindowIterator)
+    return (x.data == y.data) && (x.width == y.width) && (x.step == y.step)
 end
 
 """
@@ -65,7 +77,7 @@ end
 @inline function next{T <: AbstractString}(it::EachWindowIterator{T}, state::Integer)
     i = state
     window = it.data[i:i + it.width - 1]
-    return window
+    return window, i + it.step
 end
 
 @inline function done(it::EachWindowIterator, state::Integer)

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -25,7 +25,6 @@ end
     return 1
 end
 
-
 @inline function next{T}(it::EachWindowIterator{T}, state::Integer)
     i = state
     window = sub(it.vec, i:i+it.K - 1)

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,28 +1,42 @@
 
+arrayOrStringOrSeq = Union{AbstractArray, AbstractString, Sequence}
+
+
 """
 An iterator which moves across a container, as a sliding window.
 """
-immutable EachWindowIterator{T <: AbstractArray}
+immutable EachWindowIterator{T <: arrayOrStringOrSeq}
     "A reference to the collection to iterate over."
     data::T
     "The width of the sliding window."
     width::Int
     "How many positions the sliding window moves along."
     step::Int
-    "The number of windows that will result from iterating across the container."
-    nwin::Int
-    "The number of elements in the container that are missed. Typically because
-    of the width and step size of the window: some elements near the end of the
-    container are missed if window sizes and step sizes are too large."
-    nmissed::Int
+    function EachWindowIterator{T}(data::T, width::Int, step::Int = 1)
+        @assert width >= 1 "Window width must be ≥ 1."
+        @assert step >= 1 "step must be ≥ 1."
+        @assert width < length(data) "The window size cannot be greater than number of data elements."
+        return new(data, width, step)
+    end
 end
 
-function EachWindowIterator{T <: AbstractArray}(data::T, width::Int, step::Int = 1)
-    @assert width >= 1 "Window width must be ≥ 1."
-    @assert step >= 1 "step must be ≥ 1."
-    @assert width < length(data) "The window size cannot be greater than number of data elements."
-    r = StepRange(width, step, length(data))
-    return EachWindowIterator(data, width, step, length(r), length(data) - last(r))
+"""
+Calculate the number of windows that will result from iterating across the container.
+
+Accepts one variable of type EachWindowIterator.
+"""
+function size(winitr::EachWindowIterator)
+    return length(StepRange(winitr.width, winitr.step, length(winitr.data)))
+end
+
+"""
+Calculate the number of elements in the container that are missed during iteration.
+Typically because of the width and step size of the window: some elements near the end of the
+container are missed if window sizes and step sizes are too large.
+"""
+function missed(winitr::EachWindowIterator)
+    l = length(winitr.data)
+    return l - StepRange(winitr.width, winitr.step, l)
 end
 
 """
@@ -30,26 +44,27 @@ Convienient function for constructing an EachWindowIterator.
 
 Accepts the same arguments as the EachWindowIterator constructor.
 """
-eachwindow{T <: AbstractArray}(data::T, width::Integer, step::Integer = 1) = EachWindowIterator(data, width, step)
-
+function eachwindow{T <: arrayOrStringOrSeq}(data::T, width::Integer, step::Integer = 1)
+    EachWindowIterator(data, width, step)
+end
 
 @inline function start(it::EachWindowIterator)
     return 1
 end
 
-@inline function next{T <: AbstractArray}(it::EachWindowIterator{T}, state::Integer)
+@inline function next(it::EachWindowIterator, state::Integer)
     i = state
     window = sub(it.data, i:i + it.width - 1)
     return window, i + it.step
 end
 
-@inline function done{T <: AbstractArray}(it::EachWindowIterator{T}, state::Integer)
+@inline function done(it::EachWindowIterator, state::Integer)
     return (state + it.width - 1) > length(it.data)
 end
 
-function show{T <: AbstractArray}(io::IO, it::EachWindowIterator{T})
+function show(io::IO, it::EachWindowIterator)
     print(io, "Sliding window iterator.\nContainer size: ", length(it.data), " elements.",
     "\nWindow width: ", it.width, "\nStep distance: ", it.step,
-    "\nTotal windows: ", it.nwin, "\nMissed elements: ",
-    it.nmissed)
+    "\nTotal windows: ", size(it), "\nMissed elements: ",
+    missed(it))
 end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,9 +1,4 @@
-
-import Base:
-    start,
-    next,
-    done
-
+# Iterate through every window of size K in vec
 
 immutable EachWindowIterator{T}
     vec::Vector{T}

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,9 +1,4 @@
-import Base:
-    start,
-    next,
-    done
-
-# Iterate through every window in type
+# Iterate through every window of size K in vec
 immutable EachWindowIterator{T}
     vec::Vector{T}
     K::Int
@@ -32,8 +27,8 @@ end
 
 function next{T}(it::EachWindowIterator{T}, state::Integer)
     i = state
-    value = sub(it.vec, i:i+it.K - 1)
-    return value, i + it.step
+    window = sub(it.vec, i:i+it.K - 1)
+    return window, i + it.step
 end
 
 function done{T}(it::EachWindowIterator{T}, state::Integer)

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -1,36 +1,55 @@
-# Iterate through every window of size K in vec
 
-immutable EachWindowIterator{T}
-    vec::Vector{T}
-    K::Int
+"""
+An iterator which moves across a container, as a sliding window.
+"""
+immutable EachWindowIterator{T <: AbstractArray}
+    "A reference to the collection to iterate over."
+    data::T
+    "The width of the sliding window."
+    width::Int
+    "How many positions the sliding window moves along."
     step::Int
-    npos::Int  # Number of windows, length(vec) - K + step
-
-    EachWindowIterator(vec, K, step=1) = new(vec, K, step, length(vec) - K + 1)
+    "The number of windows that will result from iterating across the container."
+    nwin::Int
+    "The number of elements in the container that are missed. Typically because
+    of the width and step size of the window: some elements near the end of the
+    container are missed if window sizes and step sizes are too large."
+    nmissed::Int
 end
 
-immutable EachWindowIteratorState{T}
-    i::Int  # start position of current window
+function EachWindowIterator{T <: AbstractArray}(data::T, width::Int, step::Int = 1)
+    @assert width >= 1 "Window width must be ≥ 1."
+    @assert step >= 1 "step must be ≥ 1."
+    @assert width < length(data) "The window size cannot be greater than number of data elements."
+    r = StepRange(width, step, length(data))
+    return EachWindowIterator(data, width, step, length(r), length(data) - last(r))
 end
 
-function eachwindow{T}(K::Integer, vec::Vector{T}, step::Integer=1)
-    @assert K >= 0 "K (window size) must be ≥ 0 in EachWindow"
-    @assert step >= 1 "step must be ≥ 1"
+"""
+Convienient function for constructing an EachWindowIterator.
 
-    return EachWindowIterator{T}(vec, K, step)
-end
+Accepts the same arguments as the EachWindowIterator constructor.
+"""
+eachwindow{T <: AbstractArray}(data::T, width::Integer, step::Integer = 1) = EachWindowIterator(data, width, step)
 
 
 @inline function start(it::EachWindowIterator)
     return 1
 end
 
-@inline function next{T}(it::EachWindowIterator{T}, state::Integer)
+@inline function next{T <: AbstractArray}(it::EachWindowIterator{T}, state::Integer)
     i = state
-    window = sub(it.vec, i:i+it.K - 1)
+    window = sub(it.data, i:i + it.width - 1)
     return window, i + it.step
 end
 
-@inline function done{T}(it::EachWindowIterator{T}, state::Integer)
-    return state > it.npos
+@inline function done{T <: AbstractArray}(it::EachWindowIterator{T}, state::Integer)
+    return (state + it.width - 1) > length(it.data)
+end
+
+function show{T <: AbstractArray}(io::IO, it::EachWindowIterator{T})
+    print(io, "Sliding window iterator.\nContainer size: ", length(it.data), " elements.",
+    "\nWindow width: ", it.width, "\nStep distance: ", it.step,
+    "\nTotal windows: ", it.nwin, "\nMissed elements: ",
+    it.nmissed)
 end

--- a/test/TestFunctions.jl
+++ b/test/TestFunctions.jl
@@ -1,0 +1,25 @@
+module TestFunctions
+
+
+export get_bio_fmt_specimens,
+    random_array
+
+
+function get_bio_fmt_specimens()
+    path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
+    if !isdir(path)
+        run(`git clone --depth 1 https://github.com/BioJulia/BioFmtSpecimens.git $(path)`)
+    end
+end
+
+function random_array(n::Integer, elements, probs)
+    cumprobs = cumsum(probs)
+    x = Array(eltype(elements), n)
+    for i in 1:n
+        x[i] = elements[searchsorted(cumprobs, rand()).start]
+    end
+    return x
+end
+
+
+end

--- a/test/TestFunctions.jl
+++ b/test/TestFunctions.jl
@@ -1,5 +1,6 @@
 module TestFunctions
 
+using Bio.Seq
 
 export get_bio_fmt_specimens,
     random_array
@@ -12,6 +13,8 @@ function get_bio_fmt_specimens()
     end
 end
 
+# The generation of random test cases...
+
 function random_array(n::Integer, elements, probs)
     cumprobs = cumsum(probs)
     x = Array(eltype(elements), n)
@@ -21,5 +24,22 @@ function random_array(n::Integer, elements, probs)
     return x
 end
 
+# Return a random DNA/RNA sequence of the given length.
+function random_seq(n::Integer, nts, probs)
+    cumprobs = cumsum(probs)
+    x = Array(Char, n)
+    for i in 1:n
+        x[i] = nts[searchsorted(cumprobs, rand()).start]
+    end
+    return convert(AbstractString, x)
+end
+
+function random_dna(n, probs=[0.24, 0.24, 0.24, 0.24, 0.04])
+    return random_seq(n, ['A', 'C', 'G', 'T', 'N'], probs)
+end
+
+function random_rna(n, probs=[0.24, 0.24, 0.24, 0.24, 0.04])
+    return random_seq(n, ['A', 'C', 'G', 'U', 'N'], probs)
+end
 
 end

--- a/test/TestFunctions.jl
+++ b/test/TestFunctions.jl
@@ -3,7 +3,10 @@ module TestFunctions
 using Bio.Seq
 
 export get_bio_fmt_specimens,
-    random_array
+    random_array,
+    random_seq,
+    random_dna,
+    random_rna
 
 
 function get_bio_fmt_specimens()

--- a/test/TestFunctions.jl
+++ b/test/TestFunctions.jl
@@ -6,7 +6,8 @@ export get_bio_fmt_specimens,
     random_array,
     random_seq,
     random_dna,
-    random_rna
+    random_rna,
+    random_aa
 
 
 function get_bio_fmt_specimens()
@@ -43,6 +44,13 @@ end
 
 function random_rna(n, probs=[0.24, 0.24, 0.24, 0.24, 0.04])
     return random_seq(n, ['A', 'C', 'G', 'U', 'N'], probs)
+end
+
+function random_aa(len)
+    return random_seq(len,
+        ['A', 'R', 'N', 'D', 'C', 'Q', 'E', 'G', 'H', 'I',
+         'L', 'K', 'M', 'F', 'P', 'S', 'T', 'W', 'Y', 'V', 'X' ],
+        push!(fill(0.049, 20), 0.02))
 end
 
 end

--- a/test/align/TestAlign.jl
+++ b/test/align/TestAlign.jl
@@ -3,6 +3,7 @@ module TestAlign
 using FactCheck
 using Bio
 using Bio.Align
+using TestFunctions
 
 
 # Generate a random valid alignment of a sequence of length n against a sequence

--- a/test/intervals/TestIntervals.jl
+++ b/test/intervals/TestIntervals.jl
@@ -3,10 +3,8 @@ module TestIntervals
 using FactCheck,
     Bio.Intervals,
     Distributions,
-    YAML
-
-import ..get_bio_fmt_specimens
-
+    YAML,
+    TestFunctions
 
 # Test that an array of intervals is well ordered
 function Intervals.isordered{I <: Interval}(intervals::Vector{I})
@@ -358,6 +356,8 @@ facts("Interval Parsing") do
     context("BED Parsing") do
         get_bio_fmt_specimens()
 
+        println("DONE THE GET SPECIMENS!")
+
         function check_bed_parse(filename)
             # Reading from a stream
             for interval in open(open(filename), BED)
@@ -387,8 +387,13 @@ facts("Interval Parsing") do
             return expected_entries == read_entries
         end
 
+        println("DONE FUNCTION LOADING!")
+
         path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "BED")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
+
+            println("NOW ON $specimen")
+
             valid = get(specimen, "valid", true)
             if valid
                 @fact check_bed_parse(joinpath(path, specimen["filename"])) --> true

--- a/test/intervals/TestIntervals.jl
+++ b/test/intervals/TestIntervals.jl
@@ -183,7 +183,9 @@ facts("IntervalCollection") do
 
 
     context("Show") do
-        nullout = open("/dev/null", "w")
+        nullstream = @windows ? "NUL" : "/dev/null"
+        nullout = open(nullstream, "w")
+
 
         ic = IntervalCollection{Int}()
         show(nullout, ic)

--- a/test/intervals/TestIntervals.jl
+++ b/test/intervals/TestIntervals.jl
@@ -181,26 +181,22 @@ facts("IntervalCollection") do
 
 
     context("Show") do
-        nullstream = @windows ? "NUL" : "/dev/null"
-        nullout = open(nullstream, "w")
-
-
         ic = IntervalCollection{Int}()
-        show(nullout, ic)
+        show(DevNull, ic)
 
         push!(ic, Interval{Int}("one", 1, 1000, STRAND_POS, 0))
-        show(nullout, ic)
+        show(DevNull, ic)
 
         intervals = random_intervals(["one", "two", "three"], 1000000, 100)
         for interval in intervals
             push!(ic, interval)
         end
-        show(nullout, ic)
+        show(DevNull, ic)
 
-        show(nullout, STRAND_NA)
-        show(nullout, STRAND_POS)
-        show(nullout, STRAND_NEG)
-        show(nullout, STRAND_BOTH)
+        show(DevNull, STRAND_NA)
+        show(DevNull, STRAND_POS)
+        show(DevNull, STRAND_NEG)
+        show(DevNull, STRAND_BOTH)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,10 @@
 
-function get_bio_fmt_specimens()
-    path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
-    if !isdir(path)
-        run(`git clone --depth 1 https://github.com/BioJulia/BioFmtSpecimens.git $(path)`)
-    end
-end
 
+include("TestFunctions.jl")
 include("align/TestAlign.jl")
 include("phylo/TestPhylo.jl")
 include("intervals/TestIntervals.jl")
 include("seq/TestSeq.jl")
 include("services/TestServices.jl")
 include("tools/TestTools.jl")
+include("util/TestUtil.jl")

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -6,26 +6,6 @@ using FactCheck,
     TestFunctions
     
 
-# Return a random DNA/RNA sequence of the given length
-function random_seq(n::Integer, nts, probs)
-    cumprobs = cumsum(probs)
-    x = Array(Char, n)
-    for i in 1:n
-        x[i] = nts[searchsorted(cumprobs, rand()).start]
-    end
-    return convert(AbstractString, x)
-end
-
-
-function random_dna(n, probs=[0.24, 0.24, 0.24, 0.24, 0.04])
-    return random_seq(n, ['A', 'C', 'G', 'T', 'N'], probs)
-end
-
-
-function random_rna(n, probs=[0.24, 0.24, 0.24, 0.24, 0.04])
-    return random_seq(n, ['A', 'C', 'G', 'U', 'N'], probs)
-end
-
 const codons = [
         "AAA", "AAC", "AAG", "AAU",
         "ACA", "ACC", "ACG", "ACU",

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -2,9 +2,9 @@ module TestSeq
 
 using FactCheck,
     Bio.Seq,
-    YAML
-
-import ..get_bio_fmt_specimens
+    YAML,
+    TestFunctions
+    
 
 # Return a random DNA/RNA sequence of the given length
 function random_seq(n::Integer, nts, probs)
@@ -14,16 +14,6 @@ function random_seq(n::Integer, nts, probs)
         x[i] = nts[searchsorted(cumprobs, rand()).start]
     end
     return convert(AbstractString, x)
-end
-
-
-function random_array(n::Integer, elements, probs)
-    cumprobs = cumsum(probs)
-    x = Array(eltype(elements), n)
-    for i in 1:n
-        x[i] = elements[searchsorted(cumprobs, rand()).start]
-    end
-    return x
 end
 
 
@@ -259,7 +249,7 @@ facts("Nucleotides") do
         end
         @fact takebuf_string(buf) --> "ACGTN"
     end
-    
+
     context("Show RNA") do
         buf = IOBuffer()
         for nt in [RNA_A, RNA_C, RNA_G, RNA_U, RNA_N]

--- a/test/seq/TestSeq.jl
+++ b/test/seq/TestSeq.jl
@@ -4,7 +4,7 @@ using FactCheck,
     Bio.Seq,
     YAML,
     TestFunctions
-    
+
 
 const codons = [
         "AAA", "AAC", "AAG", "AAU",
@@ -61,14 +61,6 @@ end
 function random_rna_kmer_nucleotides(len)
     return random_array(len, [RNA_A, RNA_C, RNA_G, RNA_U],
                         [0.25, 0.25, 0.25, 0.25])
-end
-
-
-function random_aa(len)
-    return random_seq(len,
-        ['A', 'R', 'N', 'D', 'C', 'Q', 'E', 'G', 'H', 'I',
-         'L', 'K', 'M', 'F', 'P', 'S', 'T', 'W', 'Y', 'V', 'X' ],
-        push!(fill(0.049, 20), 0.02))
 end
 
 

--- a/test/util/TestUtil.jl
+++ b/test/util/TestUtil.jl
@@ -1,0 +1,54 @@
+module TestUtil
+
+using FactCheck,
+    Bio.Util,
+    TestFunctions
+
+facts("Sliding-Windows") do
+    context("Creation") do
+        # Test EachWindow iterators are created correctly when given sensible values.
+        # Randomly create some sequences of a random length.
+        # Then randomly assign each sequence a winsow size and step size.
+        context("Sensible values") do
+            for i in 1:100
+                n = rand(1:1000)
+                seq = collect(1:n)
+                winsize = rand(1:length(seq))
+                stepsize = rand(1:length(seq))
+                itr = eachwindow(seq, winsize, stepsize)
+                @fact itr --> EachWindowIterator(seq, winsize, stepsize)
+                @fact itr.width --> winsize
+                @fact itr.step --> stepsize
+                @fact itr.data --> seq
+            end
+        end
+        context("Bad values") do
+            for i in 1:100
+                n = rand(1:1000)
+                seq = collect(1:n)
+                winsize = rand(length(seq):length(seq) + rand(1:1000))
+                stepsize = rand(length(seq):length(seq) + rand(1:1000))
+                @fact_throws eachwindow(seq, winsize, stepsize)
+            end
+        end
+    end
+    context("Iteration") do
+        context("Number and size of Windows") do
+            for i in 1:100
+                n = rand(1:1000)
+                seq = collect(1:n)
+                winsize = rand(1:length(seq))
+                stepsize = rand(1:length(seq))
+                itr = eachwindow(seq, winsize, stepsize)
+                res = collect(itr)
+                @fact length(res) --> itr.nwin
+                for win in res
+                    @fact length(res) --> winsize
+                end
+            end
+        end
+    end
+end
+
+
+end

--- a/test/util/TestUtil.jl
+++ b/test/util/TestUtil.jl
@@ -14,7 +14,7 @@ facts("Sliding-Windows") do
                 n = rand(1:1000)
                 testarray = collect(1:n)
                 teststring = randstring(n)
-                testseq = random_dna(n)
+                testseq = DNASequence(random_dna(n))
                 winsize = rand(1:n)
                 stepsize = rand(1:n)
                 arrayitr = eachwindow(testarray, winsize, stepsize)
@@ -39,7 +39,7 @@ facts("Sliding-Windows") do
                 n = rand(1:1000)
                 testarray = collect(1:n)
                 teststring = randstring(n)
-                testseq = random_dna(n)
+                testseq = DNASequence(random_dna(n))
                 winsize = rand(n:n + rand(1:1000))
                 stepsize = rand(n:n + rand(1:1000))
                 @fact_throws eachwindow(testarray, winsize, stepsize)
@@ -49,29 +49,33 @@ facts("Sliding-Windows") do
         end
     end
     context("Iteration") do
-        context("Number and size of Windows") do
+        context("Number and size of Windows, and missed elements") do
             for i in 1:100
                 n = rand(1:1000)
                 testarray = collect(1:n)
                 teststring = randstring(n)
-                testseq = random_dna(n)
+                testseq = DNASequence(random_dna(n))
                 winsize = rand(1:n)
                 stepsize = rand(1:n)
                 arrayitr = eachwindow(testarray, winsize, stepsize)
                 stringitr = eachwindow(teststring, winsize, stepsize)
                 seqitr = eachwindow(testseq, winsize, stepsize)
                 arrayres = collect(arrayitr)
-                stringres = collect(stringitr)
+                #stringres = collect(stringitr)
                 seqres = collect(seqitr)
+                expectedMissed = n - StepRange(winsize, stepsize, n)
                 @fact length(arrayres) --> size(arrayitr)
                 @fact length(stringres) --> size(stringitr)
                 @fact length(seqres) --> size(seqitr)
+                @fact missed(arrayres) --> expectedMissed
+                @fact missed(stringres) --> expectedMissed
+                @fact missed(seqres) --> expectedMissed
                 for win in arrayres
                     @fact length(win) --> winsize
                 end
-                for win in stringres
-                    @fact length(win) --> winsize
-                end
+                #for win in stringres
+                #    @fact length(win) --> winsize
+                #end
                 for win in seqres
                     @fact length(win) --> winsize
                 end

--- a/test/util/TestUtil.jl
+++ b/test/util/TestUtil.jl
@@ -37,10 +37,14 @@ facts("Sliding-Windows") do
         context("Bad values") do
             for i in 1:100
                 n = rand(1:1000)
-                seq = collect(1:n)
-                winsize = rand(length(seq):length(seq) + rand(1:1000))
-                stepsize = rand(length(seq):length(seq) + rand(1:1000))
-                @fact_throws eachwindow(seq, winsize, stepsize)
+                testarray = collect(1:n)
+                teststring = randstring(n)
+                testseq = random_dna(n)
+                winsize = rand(n:n + rand(1:1000))
+                stepsize = rand(n:n + rand(1:1000))
+                @fact_throws eachwindow(testarray, winsize, stepsize)
+                @fact_throws eachwindow(teststring, winsize, stepsize)
+                @fact_throws eachwindow(testseq, winsize, stepsize)
             end
         end
     end
@@ -48,14 +52,28 @@ facts("Sliding-Windows") do
         context("Number and size of Windows") do
             for i in 1:100
                 n = rand(1:1000)
-                seq = collect(1:n)
-                winsize = rand(1:length(seq))
-                stepsize = rand(1:length(seq))
-                itr = eachwindow(seq, winsize, stepsize)
-                res = collect(itr)
-                @fact length(res) --> size(itr)
-                for win in res
-                    @fact length(res) --> winsize
+                testarray = collect(1:n)
+                teststring = randstring(n)
+                testseq = random_dna(n)
+                winsize = rand(1:n)
+                stepsize = rand(1:n)
+                arrayitr = eachwindow(testarray, winsize, stepsize)
+                stringitr = eachwindow(teststring, winsize, stepsize)
+                seqitr = eachwindow(testseq, winsize, stepsize)
+                arrayres = collect(arrayitr)
+                stringres = collect(stringitr)
+                seqres = collect(seqitr)
+                @fact length(arrayres) --> size(arrayitr)
+                @fact length(stringres) --> size(stringitr)
+                @fact length(seqres) --> size(seqitr)
+                for win in arrayres
+                    @fact length(win) --> winsize
+                end
+                for win in stringres
+                    @fact length(win) --> winsize
+                end
+                for win in seqres
+                    @fact length(win) --> winsize
                 end
             end
         end

--- a/test/util/TestUtil.jl
+++ b/test/util/TestUtil.jl
@@ -12,14 +12,26 @@ facts("Sliding-Windows") do
         context("Sensible values") do
             for i in 1:100
                 n = rand(1:1000)
-                seq = collect(1:n)
-                winsize = rand(1:length(seq))
-                stepsize = rand(1:length(seq))
-                itr = eachwindow(seq, winsize, stepsize)
-                @fact itr --> EachWindowIterator(seq, winsize, stepsize)
-                @fact itr.width --> winsize
-                @fact itr.step --> stepsize
-                @fact itr.data --> seq
+                testarray = collect(1:n)
+                teststring = randstring(n)
+                testseq = random_dna(n)
+                winsize = rand(1:n)
+                stepsize = rand(1:n)
+                arrayitr = eachwindow(testarray, winsize, stepsize)
+                stritr = eachwindow(teststring, winsize, stepsize)
+                seqitr = eachwindow(testseq, winsize, stepsize)
+                @fact arrayitr --> EachWindowIterator(testarray, winsize, stepsize)
+                @fact stritr --> EachWindowIterator(teststring, winsize, stepsize)
+                @fact seqitr --> EachWindowIterator(testseq, winsize, stepsize)
+                @fact arrayitr.width --> winsize
+                @fact stritr.width --> winsize
+                @fact seqitr.width --> winsize
+                @fact arrayitr.step --> stepsize
+                @fact stritr.step --> stepsize
+                @fact seqitr.step --> stepsize
+                @fact arrayitr.data --> testarray
+                @fact stritr.data --> teststring
+                @fact seqitr.data --> testseq
             end
         end
         context("Bad values") do

--- a/test/util/TestUtil.jl
+++ b/test/util/TestUtil.jl
@@ -41,7 +41,7 @@ facts("Sliding-Windows") do
                 stepsize = rand(1:length(seq))
                 itr = eachwindow(seq, winsize, stepsize)
                 res = collect(itr)
-                @fact length(res) --> itr.nwin
+                @fact length(res) --> size(itr)
                 for win in res
                     @fact length(res) --> winsize
                 end


### PR DESCRIPTION
Modified slightly the sliding windows code of @kdmurray91 - instead of requireing a vector of something, it is parametric and works fo any type T (instead of Vector{T}) that implements the sub() method. I added the sub() method for nucelotide sequences too - which is the same as constructing a subsequence with `seq[x:y]`. 

A rebase was done so thought it was easier to just open a new PR and then close both, than try and merge or push back to the origional PR. But @kdmurray91's contribution is reflected in the commit history.