### PR TITLE
Fixing tests and code for AppVeyor

### DIFF
--- a/test/intervals/TestIntervals.jl
+++ b/test/intervals/TestIntervals.jl
@@ -183,7 +183,9 @@ facts("IntervalCollection") do
 
 
     context("Show") do
-        nullout = open("/dev/null", "w")
+        nullstream = @windows ? "NUL" : "/dev/null"
+        nullout = open(nullstream, "w")
+
 
         ic = IntervalCollection{Int}()
         show(nullout, ic)


### PR DESCRIPTION
There was an issue with AppVeyor as a test used /dev/null, which doesen't exist on windows, it has to be NUL instead.

Let's get the AppVeyor badge coloured green!