### PR TITLE
add constructors of AlignedSequence from BioSequences

### DIFF
--- a/docs/src/man/alignments.md
+++ b/docs/src/man/alignments.md
@@ -59,6 +59,17 @@ Using anchors we would represent this as the following series of anchors:
 ]
 ```
 
+An `Alignment` object can be created from a series of anchors:
+```julia
+julia> Alignment([
+           AlignmentAnchor(0, 4, OP_START),
+           AlignmentAnchor(4, 8, OP_MATCH),
+           AlignmentAnchor(4, 12, OP_DELETE)
+       ])
+········
+····----
+```
+
 
 ### Operations
 
@@ -79,6 +90,56 @@ format](https://samtools.github.io/hts-specs/SAMv1.pdf) and are stored in the
 | `OP_SEQ_MISMATCH`    | match              | match operation with mismatching sequence positions                             |
 | `OP_BACK`            | special            | not currently supported, but present for SAM/BAM compatibility                  |
 | `OP_START`           | special            | indicate the start of an alignment within the reference and query sequence      |
+
+
+## Aligned sequence
+
+A sequence aligned to another sequence is represented by the `AlignedSequence`
+type, which is a pair of the aligned sequence and an `Alignment` object.
+
+The following example creates an aligned sequence object from a sequence and an
+alignment:
+```julia
+julia> AlignedSequence(  # pass an Alignment object
+           dna"ACGTAT",
+           Alignment([
+               AlignmentAnchor(0, 0, OP_START),
+               AlignmentAnchor(3, 3, OP_MATCH),
+               AlignmentAnchor(6, 3, OP_INSERT)
+           ])
+       )
+···---
+ACGTAT
+
+julia> AlignedSequence(  # or pass a vector of anchors
+           dna"ACGTAT",
+           [
+               AlignmentAnchor(0, 0, OP_START),
+               AlignmentAnchor(3, 3, OP_MATCH),
+               AlignmentAnchor(6, 3, OP_INSERT)
+           ]
+       )
+···---
+ACGTAT
+
+```
+
+If you already have an aligned sequence with gap symbols, it can be converted to
+an `AlignedSequence` object by passing a reference sequence with it:
+```julia
+julia> seq = dna"ACGT--AAT--"
+11nt DNA Sequence:
+ACGT--AAT--
+
+julia> ref = dna"ACGTTTAT-GG"
+11nt DNA Sequence:
+ACGTTTAT-GG
+
+julia> AlignedSequence(seq, ref)
+········-··
+ACGT--AAT--
+
+```
 
 
 ## Operating on alignments

--- a/src/align/anchors.jl
+++ b/src/align/anchors.jl
@@ -255,17 +255,54 @@ immutable AlignedSequence{S}
     aln::Alignment
 end
 
-
-function AlignedSequence{S}(seq::S, aln::Alignment)
-    return AlignedSequence{S}(seq, aln)
-end
-
-
 function AlignedSequence{S}(seq::S, anchors::Vector{AlignmentAnchor},
                             check::Bool=true)
     return AlignedSequence(seq, Alignment(anchors, check))
 end
 
+function AlignedSequence(seq::Sequence, ref::Sequence)
+    return AlignedSequence(seq, 1, ref, 1)
+end
+
+function AlignedSequence(seq::Sequence, seqpos::Integer,
+                         ref::Sequence, refpos::Integer)
+    if length(seq) != length(ref)
+        throw(ArgumentError("two sequences must be the same length"))
+    end
+    seqpos -= 1
+    refpos -= 1
+    op = OP_START
+    newseq = similar(seq, 0)  # sequence without gap symbols
+    anchors = AlignmentAnchor[]
+    for (x, y) in zip(seq, ref)
+        if x == gap(eltype(seq)) && y == gap(eltype(ref))
+            throw(ArgumentError("two sequences must not have gaps at the same position"))
+        elseif x == gap(eltype(seq))
+            op′ = OP_DELETE
+        elseif y == gap(eltype(ref))
+            op′ = OP_INSERT
+        elseif x == y
+            op′ = OP_SEQ_MATCH
+        else
+            op′ = OP_SEQ_MISMATCH
+        end
+
+        if op′ != op
+            push!(anchors, AlignmentAnchor(seqpos, refpos, op))
+            op = op′
+        end
+
+        if x != gap(eltype(seq))
+            seqpos += 1
+            push!(newseq, x)
+        end
+        if y != gap(eltype(ref))
+            refpos += 1
+        end
+    end
+    push!(anchors, AlignmentAnchor(seqpos, refpos, op))
+    return AlignedSequence(newseq, anchors)
+end
 
 """
 First position in the reference sequence.
@@ -291,7 +328,7 @@ function ref2seq(i::Integer, alnseq::AlignedSequence)
 end
 
 # simple letters and dashes representation of an alignment
-function show(io::IO, alnseq::AlignedSequence)
+function Base.show(io::IO, alnseq::AlignedSequence)
     # print a representation of the reference sequence
     anchors = alnseq.aln.anchors
     for i in 2:length(anchors)

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -196,6 +196,22 @@ end
         @test ref2seq( 9, alnseq) == ( 4, OP_DELETE)
         @test ref2seq(10, alnseq) == ( 4, OP_DELETE)
         @test ref2seq(23, alnseq) == (15, OP_DELETE)
+
+        seq = dna"ACGG--TGAAAGGT"
+        ref = dna"-CGGGGA----TTT"
+        alnseq = AlignedSequence(seq, ref)
+        @test Bio.Align.first(alnseq) == 1
+        @test Bio.Align.last(alnseq)  == 9
+        @test alnseq.aln.anchors == [
+             AlignmentAnchor( 0, 0, '0')
+             AlignmentAnchor( 1, 0, 'I')
+             AlignmentAnchor( 4, 3, '=')
+             AlignmentAnchor( 4, 5, 'D')
+             AlignmentAnchor( 5, 6, 'X')
+             AlignmentAnchor( 9, 6, 'I')
+             AlignmentAnchor(11, 8, 'X')
+             AlignmentAnchor(12, 9, '=')
+        ]
     end
 end
 


### PR DESCRIPTION
This adds constructors that create `AlignedSequence` from `BioSequence`s with gap symbols.
I still need to add tests and docs, but it's time to go to bed :sleeping:.

@kescobo Does this meet your demand?