### PR TITLE
Exact search/rsearch for sequences.

### DIFF
--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -538,6 +538,70 @@ on `Kmers`.
     neighbors
 
 
+## Sequence search
+
+Several kinds of on-line search functions are provided.
+
+### Exact search
+
+Exact search functions search for the first occurrence of the query symbol or
+sequence. Four functions, `search`, `searchindex`, `rsearch`, and
+`rsearchindex`, are available:
+```julia
+julia> seq = dna"ACAGCGTAGCT";
+
+julia> search(seq, DNA_G)  # search a query symbol
+4:4
+
+julia> query = dna"AGC";
+
+julia> search(seq, query)  # search a query sequence
+3:5
+
+julia> searchindex(seq, query)
+3
+
+julia> rsearch(seq, query)  # similar to `search` but in the reverse direction
+8:10
+
+julia> rsearchindex(seq, query)  # similar to `searchindex` but in the reverse direction
+8
+
+```
+
+These search functions take ambiguous symbols into account. That is, if two
+symbols are compatible (e.g. `DNA_A` and `DNA_N`), they match when searching an
+occurrence. In the following example, 'N' is a wild card that matches any
+symbols:
+```julia
+julia> search(dna"ACNT", DNA_N)  # 'A' matches 'N'
+1:1
+
+julia> search(dna"ACNT", dna"CGT")  # 'N' matches 'G'
+2:4
+
+julia> search(dna"ACGT", dna"CNT")  # 'G' matches 'N'
+2:4
+
+```
+
+The exact sequence search needs preprocessing phase of query sequence before
+searching phase. This would be enough fast for most search applications. But
+when searching a query sequence to large amounts of target sequences, caching
+the result of preprocessing may save time. The `ExactSearchQuery` creates such
+a preprocessed query object and is applicable to the search functions:
+```julia
+julia> query = ExactSearchQuery(dna"ATT");
+
+julia> search(dna"ATTTATT", query)
+1:3
+
+julia> rsearch(dna"ATTTATT", query)
+5:7
+
+```
+
+
 ## Sequence records
 
 The `SeqRecord` type is used to represent a named sequence, optionally with

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -119,7 +119,8 @@ export
     DNAAlphabet,
     RNAAlphabet,
     AminoAcidAlphabet,
-    CharAlphabet
+    CharAlphabet,
+    ExactSearchQuery
 
 using
     Compat,
@@ -183,6 +184,8 @@ include("fasta.jl")
 include("fasta-parser.jl")
 include("fastq.jl")
 include("fastq-parser.jl")
+
+include("search/exact.jl")
 
 # DEPRECATED: defined just for compatibility
 type NucleotideSequence{T<:Nucleotide} end

--- a/src/seq/search/exact.jl
+++ b/src/seq/search/exact.jl
@@ -1,0 +1,307 @@
+# Exact Search
+# ============
+
+# Reference Implementation
+# ------------------------
+#
+# `searchindex` and `rsearchindex` should work exactly the same way as the
+# following reference implementation:
+#=
+# Return the index of the first occurrence of `pat` in `seq[start:stop]`.
+function searchindex(seq, pat, start=1, stop=endof(seq))
+    m = length(pat)
+    n = length(seq)
+    for s in max(start-1, 0):min(stop, n)-m
+        if occurs_with_shift(pat, seq, s)
+            return s+1  # found
+        end
+    end
+    return 0  # not found
+end
+
+# Return the index of the last occurrence of `pat` in `seq[stop:start]`.
+function rsearchindex(seq, pat, start=endof(seq), stop=1)
+    n = length(seq)
+    m = length(pat)
+    for s in min(start, n)-m:-1:max(stop-1, 0)
+        if occurs_with_shift(pat, seq, s)
+            return s+1  # found
+        end
+    end
+    return 0  # not found
+end
+
+function occurs_with_shift(pat, seq, shift)
+    for i in 1:endof(pat)
+        if !iscompatible(pat[i], seq[shift+i])
+            return false
+        end
+    end
+    return true
+end
+=#
+
+
+# Actual Implementation
+# ---------------------
+
+"""
+Query type for exact sequence search.
+"""
+immutable ExactSearchQuery{S<:Sequence}
+    seq::S         # query sequence
+    cbits::UInt32  # compatibility bits
+    fshift::Int    # shift length for forward search
+    bshift::Int    # shift length for backward search
+end
+
+function ExactSearchQuery(query::Sequence)
+    cbits, fshift, bshift = preprocess(query)
+    return ExactSearchQuery(query, cbits, fshift, bshift)
+end
+
+function preprocess(query)
+    if length(query) == 0
+        return UInt32(0), 0, 0
+    end
+    m = length(query)
+    first = query[1]
+    last = query[end]
+    cbits::UInt32 = 0
+    fshift = bshift = m
+    for i in 1:endof(query)
+        x = query[i]
+        cbits |= compatbits(x)
+        if iscompatible(x, last) && i < m
+            fshift = m - i
+        end
+    end
+    for i in endof(query):-1:1
+        x = query[i]
+        if iscompatible(x, first) && i > 1
+            bshift = i - 1
+        end
+    end
+    return cbits, fshift, bshift
+end
+
+function checkeltype(seq1, seq2)
+    if eltype(seq1) != eltype(seq2)
+        throw(ArgumentError("the element type of two sequences must match"))
+    end
+end
+
+
+# Forward
+# -------
+
+
+# NOTE: the return value is a range while the counterpart for strings is an index
+"""
+    search(seq::Sequence, pat[, start=1[, stop=endof(seq)]])
+
+Return the range of the first occurrence of `pat` in `seq[start:stop]`; symbol
+comparison is done using `Bio.Seq.iscompatible`.
+"""
+function Base.search(seq::Sequence, val,
+                     start::Integer=1, stop::Integer=endof(seq))
+    s = searchindex(seq, val, start, stop)
+    if s == 0
+        return 0:-1
+    else
+        return s:s
+    end
+end
+
+function Base.search(seq::Sequence, pat::Sequence,
+                     start::Integer=1, stop::Integer=endof(seq))
+    return search(seq, ExactSearchQuery(pat), start, stop)
+end
+
+function Base.search(seq::Sequence, query::ExactSearchQuery,
+                     start::Integer=1, stop::Integer=endof(seq))
+    s = searchindex(seq, query, start, stop)
+    if s == 0
+        return 0:-1
+    end
+    return s:s+length(query.seq)-1
+end
+
+"""
+    searchindex(seq::Sequence, pat[, start=1[, stop=endof(seq)]])
+
+Return the index of the first occurrence of `pat` in `seq[start:stop]`; symbol
+comparison is done using `Bio.Seq.iscompatible`.
+"""
+function Base.searchindex(seq::Sequence, val,
+                          start::Integer=1, stop::Integer=endof(seq))
+    x = convert(eltype(seq), val)
+    for i in max(start, 1):min(stop, endof(seq))
+        if iscompatible(seq[i], x)
+            return i  # found
+        end
+    end
+    return 0  # not found
+end
+
+function Base.searchindex(seq::Sequence, pat::Sequence,
+                          start::Integer=1, stop::Integer=endof(seq))
+    return searchindex(seq, ExactSearchQuery(pat), start, stop)
+end
+
+function Base.searchindex(seq::Sequence, query::ExactSearchQuery,
+                          start::Integer=1, stop::Integer=endof(seq))
+    checkeltype(seq, query.seq)
+    return quicksearch(query, seq, start, stop)
+end
+
+# This algorithm is borrowed from base/strings/search.jl, which looks similar to
+# Sunday's Quick Search algorithm.
+function quicksearch(query, seq, start, stop)
+    pat = query.seq
+    m = length(pat)
+    n = length(seq)
+    stop′ = min(stop, n) - m
+    s::Int = max(start - 1, 0)
+
+    if m == 0  # empty query
+        if s ≤ stop′
+            return s + 1  # found
+        else
+            return 0  # not found
+        end
+    end
+
+    while s ≤ stop′
+        if iscompatible(pat[m], seq[s+m])
+            i = m - 1
+            while i > 0
+                if !iscompatible(pat[i], seq[s+i])
+                    break
+                end
+                i -= 1
+            end
+            if i == 0
+                return s + 1  # found
+            elseif s < stop′ && (query.cbits & compatbits(seq[s+m+1]) == 0)
+                s += m + 1
+            elseif isambiguous(seq[s+m])
+                s += 1
+            else
+                s += query.fshift
+            end
+        elseif s < stop′ && (query.cbits & compatbits(seq[s+m+1]) == 0)
+            s += m + 1
+        else
+            s += 1
+        end
+    end
+
+    return 0  # not found
+end
+
+
+# Backward
+# --------
+
+# NOTE: the return value is a range while the counterpart for strings is an index
+"""
+    rsearch(seq::Sequence, pat[, start=endof(seq)[, stop=1]])
+
+Return the range of the last occurrence of `pat` in `seq[start:stop]`; symbol
+comparison is done using `Bio.Seq.iscompatible`.
+"""
+function Base.rsearch(seq::Sequence, val,
+                      start::Integer=endof(seq), stop::Integer=1)
+    s = rsearchindex(seq, val, start, stop)
+    if s == 0
+        return 0:-1
+    else
+        return s:s
+    end
+end
+
+function Base.rsearch(seq::Sequence, pat::Sequence,
+                      start::Integer=endof(seq), stop::Integer=1)
+    return rsearch(seq, ExactSearchQuery(pat), start, stop)
+end
+
+function Base.rsearch(seq::Sequence, query::ExactSearchQuery,
+                      start::Integer=endof(seq), stop::Integer=1)
+    s = rsearchindex(seq, query, start, stop)
+    if s == 0
+        return 0:-1
+    end
+    return s:s+length(query.seq)-1
+end
+
+"""
+    rsearchindex(seq::Sequence, pat[, start=1[, stop=endof(seq)]])
+
+Return the index of the last occurrence of `pat` in `seq[start:stop]`; symbol
+comparison is done using `Bio.Seq.iscompatible`.
+"""
+function Base.rsearchindex(seq::Sequence, val,
+                           start::Integer=endof(seq), stop::Integer=1)
+    x = convert(eltype(seq), val)
+    for i in min(start, endof(seq)):-1:max(stop, 1)
+        if iscompatible(seq[i], x)
+            return i  # found
+        end
+    end
+    return 0  # not found
+end
+
+function Base.rsearchindex(seq::Sequence, pat::Sequence,
+                           start::Integer=endof(seq), stop::Integer=1)
+    return rsearchindex(seq, ExactSearchQuery(pat), start, stop)
+end
+
+function Base.rsearchindex(seq::Sequence, query::ExactSearchQuery,
+                           start::Integer=endof(seq), stop::Integer=1)
+    checkeltype(seq, query.seq)
+    return quickrsearch(seq, query, start, stop)
+end
+
+function quickrsearch(seq, query, start, stop)
+    pat = query.seq
+    m = length(pat)
+    n = length(seq)
+    stop′ = max(stop - 1, 0)
+    s::Int = min(start, n) - m
+
+    if m == 0  # empty query
+        if s ≥ stop′
+            return s + 1  # found
+        else
+            return 0  # not found
+        end
+    end
+
+    while s ≥ stop′
+        if iscompatible(pat[1], seq[s+1])
+            i = 2
+            while i < m + 1
+                if !iscompatible(pat[i], seq[s+i])
+                    break
+                end
+                i += 1
+            end
+            if i == m + 1
+                return s + 1  # found
+            elseif s > stop′ && (query.cbits & compatbits(seq[s]) == 0)
+                s -= m + 1
+            elseif isambiguous(seq[s+1])
+                s -= 1
+            else
+                s -= query.bshift
+            end
+        elseif s > stop′ && (query.cbits & compatbits(seq[s]) == 0)
+            s -= m + 1
+        else
+            s -= 1
+        end
+    end
+
+    return 0  # not found
+end

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -1787,6 +1787,82 @@ end
     end
 end
 
+@testset "Search" begin
+    @testset "Exact" begin
+        seq = dna"ACGTACG"
+
+        @testset "forward" begin
+            @test search(seq, DNA_A) === 1:1
+            @test search(seq, DNA_N) === 1:1
+            @test search(seq, DNA_T) === 4:4
+            @test search(seq, DNA_T, 5) === 0:-1
+            @test search(seq, DNA_A, 2, 6) === 5:5
+
+            @test search(seq, dna"") === 1:0
+            @test search(seq, dna"AC") === 1:2
+            @test search(seq, dna"AC", 2) === 5:6
+            @test search(seq, dna"AC", 2, 5) === 0:-1
+            @test search(seq, dna"TG") === 0:-1
+            @test search(seq, dna"TN") === 4:5
+            @test search(seq, dna"ACG") === 1:3
+            @test search(seq, dna"ACG", 2) === 5:7
+            @test search(seq, seq) === 1:endof(seq)
+
+            @test search(dna"", dna"") === 1:0
+            @test search(dna"", dna"", -1) === 1:0
+            @test search(dna"", dna"", 2) === 0:-1
+
+            @test searchindex(seq, dna"") === 1
+            @test searchindex(seq, dna"AC") === 1
+            @test searchindex(seq, dna"AC", 2) === 5
+            @test searchindex(seq, dna"AC", 2, 5) === 0
+
+            query = ExactSearchQuery(dna"ACG")
+            @test search(seq, query) === 1:3
+            @test search(seq, query, 2) === 5:7
+            @test search(seq, query, 2, 6) === 0:-1
+            @test searchindex(seq, query) === 1
+            @test searchindex(seq, query, 2) === 5
+            @test searchindex(seq, query, 2, 6) === 0
+        end
+
+        @testset "backward" begin
+            @test rsearch(seq, DNA_A) === 5:5
+            @test rsearch(seq, DNA_N) === 7:7
+            @test rsearch(seq, DNA_T) === 4:4
+            @test rsearch(seq, DNA_T, 3) === 0:-1
+            @test rsearch(seq, DNA_T, 6, 3) === 4:4
+
+            @test rsearch(seq, dna"") === 8:7
+            @test rsearch(seq, dna"AC") === 5:6
+            @test rsearch(seq, dna"AC", 5) === 1:2
+            @test rsearch(seq, dna"AC", 5, 2) === 0:-1
+            @test rsearch(seq, dna"TG") === 0:-1
+            @test rsearch(seq, dna"TN") === 4:5
+            @test rsearch(seq, dna"ACG") === 5:7
+            @test rsearch(seq, dna"ACG", 6) === 1:3
+            @test rsearch(seq, seq) === 1:endof(seq)
+
+            @test rsearch(dna"", dna"") === 1:0
+            @test rsearch(dna"", dna"", 2) === 1:0
+            @test rsearch(dna"", dna"", -1) === 0:-1
+
+            @test rsearchindex(seq, dna"") === 8
+            @test rsearchindex(seq, dna"AC") === 5
+            @test rsearchindex(seq, dna"AC", 5) === 1
+            @test rsearchindex(seq, dna"AC", 5, 2) === 0
+
+            query = ExactSearchQuery(dna"ACG")
+            @test rsearch(seq, query) === 5:7
+            @test rsearch(seq, query, 6) === 1:3
+            @test rsearch(seq, query, 2, 6) === 0:-1
+            @test rsearchindex(seq, query) === 5
+            @test rsearchindex(seq, query, 6) === 1
+            @test rsearchindex(seq, query, 6, 2) === 0
+        end
+    end
+end
+
 @testset "Translation" begin
     # crummy string translation to test against
     standard_genetic_code_dict = Dict{Compat.String,Char}(


### PR DESCRIPTION
This adds `search` and `rsearch` methods for sequences. These works like `Base.search`/`Base.rsearch` for strings, but match ambiguous symbols, too. In the following example, the target sequence `dna"ACGNATT"` has an ambiguous nucleotide `DNA_N` at the 4th symbol, which matches any character in the queries: 

```julia
julia> using Bio.Seq

julia> search(dna"ACGNATT", dna"ACG")
1:3

julia> search(dna"ACGNATT", dna"CGT")
2:4

julia> search(dna"ACGNATT", dna"GGA")
3:5

```

I'm now planning to implement three kinds of sequence search utils:

1. Exact search (this pull request)
2. Approximate search that allows errors (substitution/insertion/deletion) up to `k` (#153)
3. Regular expression search (#143)

The first one (this pull request) is ready to review. The second one is not yet a pull request, but I already wrote the main algorithm. The third one is also close to be a ready-to-review quality.