### PR TITLE
install NCBI BLAST+ before running Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,16 @@ julia:
   - nightly
 notifications:
   email: false
-sudo: false
+# sudo: false
+before_install:
+  - if [ `uname` = "Linux" ]; then
+      sudo apt-get -qq update;
+      sudo apt-get install -y ncbi-blast+;
+    elif [ `uname` = "Darwin" ]; then
+      brew tap homebrew/science;
+      brew update;
+      brew install blast;
+    fi
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
 script:


### PR DESCRIPTION
This would be necessary to pass tests of the BLAST wrapper.