### PR TITLE
Seqtrie: a Trie over BioSequences

### DIFF
--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -110,7 +110,21 @@ export
     DNAAlphabet,
     RNAAlphabet,
     AminoAcidAlphabet,
-    CharAlphabet
+    CharAlphabet,
+    SeqTrie,
+    DNATrie,
+    RNATrie,
+    AminoAcidTrie,
+    keys,
+    keys_with_prefix,
+    setindex!,
+    getindex,
+    get,
+    haskey,
+    hasprefix,
+    path
+
+
 
 using
     Compat,

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -117,8 +117,6 @@ export
     AminoAcidTrie,
     keys,
     keys_with_prefix,
-    setindex!,
-    getindex,
     get,
     haskey,
     hasprefix,
@@ -180,6 +178,7 @@ include("geneticcode.jl")
 include("util.jl")
 include("quality.jl")
 include("seqrecord.jl")
+include("trie.jl")
 
 # Parsing file types
 include("naivebayes.jl")

--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -511,6 +511,7 @@ function Base.append!{A}(seq::BioSequence{A}, other::BioSequence{A})
     return seq
 end
 
+
 function encode_copy!{A}(dst::BioSequence{A},
                          src::Union{AbstractVector,AbstractString})
     return encode_copy!(dst, 1, src, 1)

--- a/src/seq/trie.jl
+++ b/src/seq/trie.jl
@@ -1,0 +1,138 @@
+type SeqTrie{A<:Alphabet, T}
+    value::T
+    children::Dict{A,SeqTrie{A, T}}
+    is_key::Bool
+
+    function SeqTrie()
+        self = new()
+        self.children = Dict{A,SeqTrie{A, T}}()
+        self.is_key = false
+        return self
+    end
+
+    function SeqTrie(kv)
+        t = SeqTrie{A, T}()
+        for (k,v) in kv
+            t[k] = v
+        end
+        return t
+    end
+    SeqTrie(ks, vs) = SeqTrie(zip(ks, vs))
+end
+
+# Extra ctors
+## Typed values, aliased keys
+DNATrie{T}() = SeqTrie{DNAAlphabet, T}()
+RNATrie{T}() = SeqTrie{RNAAlphabet, T}()
+AminoAcidTrie{T}() = SeqTrie{AminoAcidAlphabet, T}()
+
+## Any values, aliased keys
+SeqTrie{A}() = SeqTrie{A, Any}()
+DNATrie() = SeqTrie{DNAAlphabet, Any}()
+RNATrie() = SeqTrie{RNAAlphabet, Any}()
+AminoAcidTrie() = SeqTrie{AminoAcidAlphabet, Any}()
+
+function setindex!{A, T}(t::SeqTrie{A, T}, val::T, key::BioSequence{A})
+    node = t
+    for char in key
+        if !haskey(node.children, char)
+            node.children[char] = SeqTrie{T}()
+        end
+        node = node.children[char]
+    end
+    node.is_key = true
+    node.value = val
+end
+
+function getindex{A, T}(t::SeqTrie{A, T}, key::BioSequence{A})
+    node = subtrie(t, key)
+    if node != nothing && node.is_key
+        return node.value
+    end
+    throw(KeyError("key not found: $key"))
+end
+
+function subtrie{A, T}(t::SeqTrie{A, T}, prefix::BioSequence{A})
+    node = t
+    for char in prefix
+        if !haskey(node.children, char)
+            return nothing
+        else
+            node = node.children[char]
+        end
+    end
+    node
+end
+
+function haskey{A, T}(t::SeqTrie{A, T}, key::BioSequence{A})
+    node = subtrie(t, key)
+    return node != nothing && node.is_key
+end
+
+function hasprefix{A, T}(t::SeqTrie{A, T}, prefix::BioSequence{A})
+    node = subtrie(t, key)
+    return node != nothing
+end
+
+function get{A, T}(t::SeqTrie{A, T}, key::BioSequence{A}, notfound)
+    node = subtrie(t, key)
+    if node != nothing && node.is_key
+        return node.value
+    end
+    notfound
+end
+
+function keys{A, T}(t::SeqTrie{A, T}, prefix::BioSequence{A}=BioSequence{A}(),
+                    found=BioSequence{A}[])
+    if t.is_key
+        push!(found, prefix)
+    end
+    for (char,child) in t.children
+        newprefix = prefix * BioSequence{A}(char)
+        keys(child, newprefix, found)
+    end
+    return found
+end
+
+function keys_with_prefix{A, T}(t::SeqTrie{A, T}, prefix::BioSequence{A})
+    st = subtrie(t, prefix)
+    st != nothing ? keys(st,prefix) : []
+end
+
+# The state of a SeqTrieIterator is a pair (t::SeqTrie, i::Int),
+# where t is the SeqTrie which was the output of the previous iteration
+# and i is the index of the current character of the string.
+# The indexing is potentially confusing;
+# see the comments and implementation below for details.
+immutable SeqTrieIterator{A, T}
+    t::SeqTrie{A, T}
+    seq::BioSequence{A}
+end
+
+# At the start, there is no previous iteration,
+# so the first element of the state is undefined.
+# We use a "dummy value" of it.t to keep the type of the state stable.
+# The second element is 0
+# since the root of the trie corresponds to a length 0 prefix of seq.
+start(it::SeqTrieIterator) = (it.t, 0)
+
+function next(it::SeqTrieIterator, state)
+    t, i = state
+    i == 0 && return it.t, (it.t, 1)
+
+    t = t.children[it.seq[i]]
+    return (t, (t, i + 1))
+end
+
+function done(it::SeqTrieIterator, state)
+    t, i = state
+    i == 0 && return false
+    i == length(it.seq) + 1 && return true
+    return !(it.seq[i] in keys(t.children))
+end
+
+path(t::SeqTrie, seq::BioSequence) = SeqTrieIterator(t, seq)
+if VERSION >= v"0.5.0-dev+3294"
+    Base.iteratorsize(::Type{SeqTrieIterator}) = Base.SizeUnknown()
+end
+

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -111,6 +111,8 @@ function random_interval(minstart, maxstop)
     return start:rand(start:maxstop)
 end
 
+include("test-seqtrie.jl")
+
 @testset "Nucleotides" begin
     @testset "Conversions" begin
         @testset "UInt8" begin
@@ -2007,62 +2009,5 @@ end
     end
 end
 
-@testset "SeqTrie" begin
-    seqs = Dict(
-        DNAAlphabet => [dna"ACGT", dna"ACGTACGT", dna"TGCA"],
-        RNAAlphabet => [rna"ACGU", rna"ACGUACGU", rna"UGCA"],
-        AminoAcidAlphabet => [aa"PWFS", aa"PWFSPWFS", aa"WCATDWG"],
-    )
-
-    @testset "Constructors" begin
-        # Alphabet aliases
-        @test DNATrie() == SeqTrie{DNAAlphabet, Any}
-        @test RNATrie() == SeqTrie{RNAAlphabet, Any}
-        @test AminoAcidTrie() == SeqTrie{AminoAcidAlphabet, Any}
-
-        # key/value list ctors
-        ks = [dna"ACGT", dna"ACGTACGT", dna"TGCA"],
-        vs = [1, 2, 3]
-        kvs = collect(zip(ks, vs))
-        @test typeof(Trie(ks, vs)) == Trie{DNAAlphabet, Int}
-        @test typeof(Trie(kvs)) == Trie{DNAAlphabet, Int}
-        @test typeof(Trie(Dict(kvs))) == Trie{DNAAlphabet, Int}
-        @test typeof(Trie(ks)) == Trie{DNAAlphabet, Void}
-    end
-
-    @testset "Basic Operations" for AB in [DNAAlphabet, RNAAlphabet, AminoAcidAlphabet]
-        t = SeqTrie{AB}()
-
-        for (i, seq) in seqs[AB]
-            t[seq] = i
-        end
-
-        for (i, seq) in seqs[AB]
-            @test haskey(t, seq)
-            @test get(t, seq, nothing) == i
-        end
-
-        @test sort(keys(t)) == seqs[AB]
-        @test sort(keys_with_prefix(t, seqs[AB][1])) == seqs[AB][1:2]
-    end
-
-    @testset "Prefix iterator" begin
-        for (i, seq) in seqs[DNAAlphabet]
-            t[seq] = i
-        end
-        t0 = t
-        t1 = t0.children[DNA_A]
-        t2 = t1.children[DNA_C]
-        t3 = t2.children[DNA_G]
-        # empty => root
-        @test collect(path(t, dna"")) == [t0]
-        # not present => root
-        @test collect(path(t, dna"G")) == [t0]
-        # prefix => correct nodes
-        @test collect(path(t, dna"ACG")) == [t0, t1, t2, t3]
-        # prefix present, key absent => correct nodes of prefix
-        @test collect(path(t, dna"ACGG")) == [t0, t1, t2, t3]
-    end
-end
 
 end # TestSeq

--- a/test/seq/test-seqtrie.jl
+++ b/test/seq/test-seqtrie.jl
@@ -1,0 +1,72 @@
+@testset "SeqTrie" begin
+    seqs = Dict(
+        DNAAlphabet{4} => [dna"ACGT", dna"ACGTACGT", dna"TGCA"],
+        RNAAlphabet{4} => [rna"ACGU", rna"ACGUACGU", rna"UGCA"],
+        AminoAcidAlphabet => [aa"PWFS", aa"PWFSPWFS", aa"WCATDWG"],
+    )
+
+    @testset "Constructors" begin
+        # Alphabet aliases
+        @test typeof(DNATrie()) == SeqTrie{DNAAlphabet{4}, Any}
+        @test typeof(RNATrie()) == SeqTrie{RNAAlphabet{4}, Any}
+        @test typeof(AminoAcidTrie()) == SeqTrie{AminoAcidAlphabet, Any}
+    end
+
+    @testset "Alias types" begin
+        d = DNATrie()
+        r = RNATrie()
+        a = AminoAcidTrie()
+
+        for (i, seqtype) in enumerate((DNASequence, RNASequence, AminoAcidSequence))
+            seq = seqtype("ACGA") # can be DNA, RNA or AA
+            for (j, trie) in enumerate((d, r, a))
+                if i == j
+                    trie[seq] = 1
+                    @test trie[seq] == 1
+                else
+                    @test_throws Exception trie[seq] = 1
+                end
+            end
+            dict = Dict{seqtype, Int}(seq => 1)
+            trie = SeqTrie(dict)
+            trie[seq] = 1
+            @test trie[seq] == 1
+        end
+    end
+
+    @testset "Basic Operations" for AB in (DNAAlphabet{4}, RNAAlphabet{4}, AminoAcidAlphabet)
+        t = SeqTrie{AB, Int}()
+
+        for (i, seq) in enumerate(seqs[AB])
+            t[seq] = i
+        end
+
+        for (i, seq) in enumerate(seqs[AB])
+            @test haskey(t, seq)
+            @test get(t, seq, nothing) == i
+        end
+
+        @test sort(keys(t)) == seqs[AB]
+        @test sort(keys_with_prefix(t, seqs[AB][1])) == seqs[AB][1:2]
+    end
+
+    @testset "Prefix iterator" begin
+        t = DNATrie()
+
+        for (i, seq) in enumerate(seqs[DNAAlphabet{4}])
+            t[seq] = i
+        end
+        t0 = t
+        t1 = t0.children[DNA_A]
+        t2 = t1.children[DNA_C]
+        t3 = t2.children[DNA_G]
+        # empty => root
+        @test collect(path(t, dna"")) == [t0]
+        # not present => root
+        @test collect(path(t, dna"G")) == [t0]
+        # prefix => correct nodes
+        @test collect(path(t, dna"ACG")) == [t0, t1, t2, t3]
+        # prefix present, key absent => correct nodes of prefix
+        @test collect(path(t, dna"ACGG")) == [t0, t1, t2, t3]
+    end
+end


### PR DESCRIPTION
This is a wholesale looting of DataStructures.jl's Trie. I've modified it to work for BioSequences. Saves BioSequence -> string -> BIosequence round trip when using Tries.

At the moment something is broken in the prefix iterator, but all other tests pass.

Cheers,
K
