### PR TITLE
Precompile

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,5 +4,5 @@ BufferedStreams 0.1
 Colors
 IntervalTrees
 Iterators
-Libz 0.1
+Libz 0.1.1
 LightXML

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -14,5 +14,6 @@ include("structure/Structure.jl")
 include("tools/blast/Blast.jl")
 include("util/indexing.jl")
 include("util/windows.jl")
+include("precompile.jl")
 
 end # module Bio

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module Bio
 
 abstract AbstractParser

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,0 +1,17 @@
+# Precompile
+# ==========
+
+# Parser
+# ------
+
+precompile(Base.open, (ASCIIString, Type{Seq.FASTA},))
+precompile(Base.read, (Seq.FASTAParser{Seq.BioSequence},))
+precompile(Base.read, (Seq.FASTAParser{Seq.DNASequence},))
+precompile(Base.read, (Seq.FASTAParser{Seq.RNASequence},))
+precompile(Base.read, (Seq.FASTAParser{Seq.AminoAcidSequence},))
+
+precompile(Base.open, (ASCIIString, Type{Seq.FASTQ},))
+precompile(Base.read, (Seq.FASTQParser{Seq.DNASequence},))
+
+precompile(Base.open, (ASCIIString, Type{Intervals.BED},))
+precompile(Base.read, (Intervals.BEDParser,))


### PR DESCRIPTION
I'm try to precompile Bio.jl module locally. Precompiling greatly cut down the load time especially for parsers.

**startup.jl**
```julia
println("--- loading ---")
tic()
using Bio.Seq
using Bio.Align
using Bio.Intervals
using Bio.Structure
toc()

println("--- running ---")
tic()
for rec in open("sample.bed", BED) end
for rec in open("sample.fasta", FASTA) end
for rec in open("sample.fastq", FASTQ) end
toc()
```

**Not precompiled (master)**
```
~/.j/v/Bio ((eeece67...)|…) $ julia startup.jl
--- loading ---
elapsed time: 7.950095168 seconds
--- running ---
elapsed time: 9.586036993 seconds
```

**Precompiled**
```
~/.j/v/Bio (precompile|…) $ julia startup.jl
--- loading ---
elapsed time: 1.373317087 seconds
--- running ---
elapsed time: 5.049919548 seconds
```

I guess there is still more room to improve it by aggressively precompiling functions. To do that, we need to benchmark the precompiling phase but currently it requires a patched Julia compiler and [SnoopCompile.jl](https://github.com/timholy/SnoopCompile.jl), which I've not tried yet. 