### PR TITLE
improve style of docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, Bio
 
-custom_deps() = run(`pip install --user pygments mkdocs mkdocs-material`)
+custom_deps() = run(`pip install --user pygments mkdocs mkdocs-cinder`)
 @osx? makedocs(doctest = false) : makedocs()
 deploydocs(
            repo = "github.com/BioJulia/Bio.jl.git",

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -11,20 +11,18 @@ repo_url:  https://github.com/BioJulia/Bio.jl
 copyright: Copyright (c) 2016 The BioJulia Organisation
 
 # Documentation and theme
-theme: material
+theme: cinder
 docs_dir: 'build'
 
 # Options
 extra:
-  logo: images/biojl.png 
+  logo: images/biojl.png
   author:
     github: BioJulia
-  palette:
-    primary: 'indigo'
-    accent:  'blue'
-  
+
 extra_css:
   - assets/Documenter.css
+  - assets/friendly.css
 
 extra_javascript:
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
@@ -36,6 +34,7 @@ markdown_extensions:
   - tables
   - fenced_code
   - codehilite
+  - def_list
 
 # Page tree
 pages:

--- a/docs/src/assets/friendly.css
+++ b/docs/src/assets/friendly.css
@@ -1,0 +1,63 @@
+/* original: https://github.com/richleland/pygments-css */
+
+.codehilite .hll { background-color: #ffffcc }
+.codehilite .c { color: #60a0b0; font-style: italic } /* Comment */
+.codehilite .err { border: 1px solid #FF0000 } /* Error */
+.codehilite .k { color: #007020; font-weight: bold } /* Keyword */
+.codehilite .o { color: #666666 } /* Operator */
+.codehilite .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.codehilite .cp { color: #007020 } /* Comment.Preproc */
+.codehilite .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.codehilite .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.codehilite .gd { color: #A00000 } /* Generic.Deleted */
+.codehilite .ge { font-style: italic } /* Generic.Emph */
+.codehilite .gr { color: #FF0000 } /* Generic.Error */
+.codehilite .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.codehilite .gi { color: #00A000 } /* Generic.Inserted */
+.codehilite .go { color: #808080 } /* Generic.Output */
+.codehilite .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.codehilite .gs { font-weight: bold } /* Generic.Strong */
+.codehilite .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.codehilite .gt { color: #0040D0 } /* Generic.Traceback */
+.codehilite .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.codehilite .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.codehilite .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.codehilite .kp { color: #007020 } /* Keyword.Pseudo */
+.codehilite .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.codehilite .kt { color: #902000 } /* Keyword.Type */
+.codehilite .m { color: #40a070 } /* Literal.Number */
+.codehilite .s { color: #4070a0 } /* Literal.String */
+.codehilite .na { color: #4070a0 } /* Name.Attribute */
+.codehilite .nb { color: #007020 } /* Name.Builtin */
+.codehilite .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.codehilite .no { color: #60add5 } /* Name.Constant */
+.codehilite .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.codehilite .ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.codehilite .ne { color: #007020 } /* Name.Exception */
+.codehilite .nf { color: #06287e } /* Name.Function */
+.codehilite .nl { color: #002070; font-weight: bold } /* Name.Label */
+.codehilite .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.codehilite .nt { color: #062873; font-weight: bold } /* Name.Tag */
+.codehilite .nv { color: #bb60d5 } /* Name.Variable */
+.codehilite .ow { color: #007020; font-weight: bold } /* Operator.Word */
+.codehilite .w { color: #bbbbbb } /* Text.Whitespace */
+.codehilite .mf { color: #40a070 } /* Literal.Number.Float */
+.codehilite .mh { color: #40a070 } /* Literal.Number.Hex */
+.codehilite .mi { color: #40a070 } /* Literal.Number.Integer */
+.codehilite .mo { color: #40a070 } /* Literal.Number.Oct */
+.codehilite .sb { color: #4070a0 } /* Literal.String.Backtick */
+.codehilite .sc { color: #4070a0 } /* Literal.String.Char */
+.codehilite .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.codehilite .s2 { color: #4070a0 } /* Literal.String.Double */
+.codehilite .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.codehilite .sh { color: #4070a0 } /* Literal.String.Heredoc */
+.codehilite .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.codehilite .sx { color: #c65d09 } /* Literal.String.Other */
+.codehilite .sr { color: #235388 } /* Literal.String.Regex */
+.codehilite .s1 { color: #4070a0 } /* Literal.String.Single */
+.codehilite .ss { color: #517918 } /* Literal.String.Symbol */
+.codehilite .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.codehilite .vc { color: #bb60d5 } /* Name.Variable.Class */
+.codehilite .vg { color: #bb60d5 } /* Name.Variable.Global */
+.codehilite .vi { color: #bb60d5 } /* Name.Variable.Instance */
+.codehilite .il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/docs/src/man/alignments.md
+++ b/docs/src/man/alignments.md
@@ -60,7 +60,7 @@ Using anchors we would represent this as the following series of anchors:
 ```
 
 An `Alignment` object can be created from a series of anchors:
-```julia
+```jlcon
 julia> Alignment([
            AlignmentAnchor(0, 4, OP_START),
            AlignmentAnchor(4, 8, OP_MATCH),
@@ -99,7 +99,7 @@ type, which is a pair of the aligned sequence and an `Alignment` object.
 
 The following example creates an aligned sequence object from a sequence and an
 alignment:
-```julia
+```jlcon
 julia> AlignedSequence(  # pass an Alignment object
            dna"ACGTAT",
            Alignment([
@@ -126,7 +126,7 @@ ACGTAT
 
 If you already have an aligned sequence with gap symbols, it can be converted to
 an `AlignedSequence` object by passing a reference sequence with it:
-```julia
+```jlcon
 julia> seq = dna"ACGT--AAT--"
 11nt DNA Sequence:
 ACGT--AAT--
@@ -162,7 +162,7 @@ A pair of optimization type and score (or cost) model determines the best
 alignments between two sequences. The next example uses a pair of
 `GlobalAlignment` and `AffineGapScoreModel` to obtain the best alignment:
 
-```julia
+```jlcon
 julia> problem = GlobalAlignment()
 Bio.Align.GlobalAlignment()
 
@@ -214,7 +214,7 @@ Alignment type can also be a distance of two sequences:
 
 In this alignment, `CostModel` is used instead of `AffineGapScoreModel` to define
 cost of substitution, insertion, and deletion:
-```julia
+```jlcon
 julia> costmodel = CostModel(match=0, mismatch=1, insertion=1, deletion=1);
 
 julia> pairalign(EditDistance(), "abcd", "adcde", costmodel)
@@ -247,7 +247,7 @@ Pairwise alignment also implements some useful operations on it.
     count_aligned
 
 The example below shows a use case of these operations:
-```julia
+```jlcon
 julia> s1 = dna"CCTAGGAGGG";
 
 julia> s2 = dna"ACCTGGTATGATAGCG";
@@ -331,7 +331,7 @@ wrapper of regular matrix.
 Some common substitution matrices are provided. For DNA and RNA, `EDNAFULL` is
 defined:
 
-```julia
+```jlcon
 julia> EDNAFULL
 Bio.Align.SubstitutionMatrix{Bio.Seq.DNANucleotide,Int64}:
      A  C  G  T  M  R  W  S  Y  K  V  H  D  B  N
@@ -356,7 +356,7 @@ Bio.Align.SubstitutionMatrix{Bio.Seq.DNANucleotide,Int64}:
 
 For amino acids, PAM (Point Accepted Mutation) and BLOSUM (BLOcks SUbstitution Matrix) matrices are defined:
 
-```julia
+```jlcon
 julia> BLOSUM62
 Bio.Align.SubstitutionMatrix{Bio.Seq.AminoAcid,Int64}:
      A  R  N  D  C  Q  E  G  H  I  L  K  M  F  P  S  T  W  Y  V  O  U  B  J  Z  X  *
@@ -400,7 +400,7 @@ These matrices are downloaded from: <ftp://ftp.ncbi.nih.gov/blast/matrices/>.
 
 `SubstitutionMatrix` can be modified like a regular matrix:
 
-```julia
+```jlcon
 julia> mysubmat = copy(BLOSUM62);  # create a copy
 
 julia> mysubmat[AA_A,AA_R]  # score of AA_A => AA_R substitution is -1
@@ -423,7 +423,7 @@ mismatching substitution.  This is a preferable choice when performance is more
 important than flexibility because looking up score is faster than
 `SubstitutionMatrix`.
 
-```julia
+```jlcon
 julia> submat = DichotomousSubstitutionMatrix(1, -1)
 Bio.Align.DichotomousSubstitutionMatrix{Int64}:
      match =  1

--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -59,7 +59,7 @@ Set of nucleotide symbols in Bio.jl covers IUPAC nucleotide base plus a gap symb
 
 Symbols are accessible as constants with `DNA_` or `RNA_` prefix:
 
-```julia
+```jlcon
 julia> DNA_A
 A
 
@@ -82,7 +82,7 @@ Bio.Seq.RNANucleotide
 
 Symbols can be constructed by converting regular characters:
 
-```julia
+```jlcon
 julia> convert(DNANucleotide, 'C')
 C
 
@@ -130,7 +130,7 @@ Set of amino acid symbols also covers IUPAC amino acid symbols plus a gap symbol
 <http://www.insdc.org/documents/feature_table.html#7.4.3>
 
 Symbols are accessible as constants with `AA_` prefix:
-```julia
+```jlcon
 julia> AA_A
 A
 
@@ -146,7 +146,7 @@ Bio.Seq.AminoAcid
 ```
 
 Symbols can be constructed by converting regular characters:
-```julia
+```jlcon
 julia> convert(AminoAcid, 'A')
 A
 
@@ -159,7 +159,7 @@ true
 ### Arithmetic
 
 Biological symbols behaves like `Char`:
-```julia
+```jlcon
 julia> DNA_A == DNA_A  # equivalence
 true
 
@@ -178,7 +178,7 @@ julia> DNA_T - DNA_C  # difference
 ```
 
 Note that these operations do **not** check bounds of valid range:
-```julia
+```jlcon
 julia> DNA_C - 2
 Invalid DNA Nucleotide
 
@@ -234,7 +234,7 @@ enumeration.
 Sequence types corresponding to these alphabets can be constructed a number of
 different ways. Most immediately, sequence literals can be constructed using
 the string macros `dna`, `rna`, `aa`, and `char`:
-```julia
+```jlcon
 # String decorators are provided for common sequence types
 julia> dna"TACGTANNATC"
 11nt DNA Sequence:
@@ -256,7 +256,7 @@ julia> char"αβγδϵ"
 
 Sequence can also be constructed from strings or arrays of nucleotide or amino
 acid symbols using constructors or the `convert` function:
-```julia
+```jlcon
 julia> DNASequence("TTANC")
 5nt DNA Sequence:
 TTANC
@@ -273,7 +273,7 @@ TTANC
 
 Using `convert`, these operations are reversible: sequences can be converted to
 strings or arrays:
-```julia
+```jlcon
 julia> convert(ASCIIString, dna"TTANGTA")
 "TTANGTA"
 
@@ -290,7 +290,7 @@ julia> convert(Vector{DNANucleotide}, dna"TTANGTA")
 ```
 
 Sequences can also be concatenated into longer sequences:
-```julia
+```jlcon
 julia> DNASequence(dna"ACGT", dna"NNNN", dna"TGCA")
 12nt DNA Sequence:
 ACGTNNNNTGCA
@@ -311,7 +311,7 @@ TATATATATATATATATATA
 
 Despite being separate types, `DNASequence` and `RNASequence` can freely be
 converted between efficiently without copying the underlying data:
-```julia
+```jlcon
 julia> dna = dna"TTANGTAGACCG"
 12nt DNA Sequence:
 TTANGTAGACCG
@@ -333,7 +333,7 @@ using the [`translate`]({ref}) function described below.
 
 Sequences for the most part behave like other vector or string types. They can
 be indexed using integers or ranges:
-```julia
+```jlcon
 julia> seq = dna"ACGTTTANAGTNNAGTACC"
 19nt DNA Sequence:
 ACGTTTANAGTNNAGTACC
@@ -352,7 +352,7 @@ Indexing by range creates a subsequence of the original sequence. Unlike
 copy-free: a subsequence is just a reference to the original sequence with its
 range.  You may think that this is unsafe because modifying subsequences
 propagates to the original sequence, but this doesn't happen actually:
-```julia
+```jlcon
 julia> seq = dna"AAAA"  # create a sequence
 4nt DNA Sequence:
 AAAA
@@ -399,7 +399,7 @@ reverse!(seq)
     reverse_complement!(seq)
 
 
-```julia
+```jlcon
 julia> seq = dna"ACG"
 3nt DNA Sequence:
 ACG
@@ -427,7 +427,7 @@ ACGTAT
 ```
 
 Sequences also work as iterators over symbols:
-```julia
+```jlcon
 julia> n = 0
 0
 
@@ -501,7 +501,7 @@ alphabet that uses two bits per base and limits to only unambiguous nucleotide
 symbols (ACGT in DNA and ACGU in RNA). To create a sequence of this
 alphabet, you need to explicitly pass `DNAAlphabet{2}` to `BioSequence` as its
 parametric type:
-```julia
+```jlcon
 julia> seq = BioSequence{DNAAlphabet{2}}("ACGT")
 4nt DNA Sequence:
 ACGT


### PR DESCRIPTION
I'm now trying to improve the style of our documents. 

Here are screenshots:

**Current**
![screen shot 2016-05-12 at 18 01 39](https://cloud.githubusercontent.com/assets/905683/15209434/eee05f74-186b-11e6-87fe-c9e061ee9163.png)

**New**
![screen shot 2016-05-12 at 18 02 03](https://cloud.githubusercontent.com/assets/905683/15209436/f1ba737e-186b-11e6-9363-d39270f7517d.png)

Pending issues are:
*  Syntax highlighter improvement: https://bitbucket.org/birkenfeld/pygments-main/pull-requests/594/fix-julialexer-and-juliaconsolelexer/diff
* Stylistic docstrings: https://github.com/MichaelHatherly/Documenter.jl/issues/48