### PR TITLE
Fix deprecated

### DIFF
--- a/src/Ragel.jl
+++ b/src/Ragel.jl
@@ -135,8 +135,8 @@ end
 # Define a read! function wrapping ragel-generated parser.  This macro handles
 # some the dirty work of maintaining state, refilling buffers, etc.
 macro generate_read_fuction(machine_name, input_type, output_type, ragel_body)
-    accept_state = symbol(machine_name, "_first_final")
-    error_state = symbol(machine_name, "_error")
+    accept_state = Symbol(machine_name, "_first_final")
+    error_state = Symbol(machine_name, "_error")
 
     esc(quote
         function Base.read!(input::$(input_type),

--- a/src/Ragel.jl
+++ b/src/Ragel.jl
@@ -11,6 +11,7 @@ module Ragel
 export tryread!
 
 using BufferedStreams
+using Compat
 using Bio:
     FileFormat,
     AbstractParser
@@ -103,7 +104,7 @@ macro ascii_from_anchor!()
         n = $(esc(:p)) - firstpos + 1
         dst = Vector{UInt8}(n)
         copy!(dst, 1, $(esc(:state)).stream.buffer, firstpos, n)
-        ASCIIString(dst)
+        Compat.ASCIIString(dst)
     end
 end
 

--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -10,6 +10,7 @@ module StringFields
 
 export StringField
 
+using Compat
 import BufferedStreams
 
 """
@@ -90,32 +91,32 @@ function Base.isempty(field::StringField)
     return field.part.start > field.part.stop
 end
 
-function Base.convert(::Type{StringField}, str::ASCIIString)
+#function Base.convert(::Type{StringField}, str::ASCIIString)
+#    return StringField(copy(str.data), 1:length(str.data))
+#end
+#
+function Base.convert(::Type{StringField}, str::Compat.String)
     return StringField(copy(str.data), 1:length(str.data))
 end
 
-function Base.convert(::Type{StringField}, str::UTF8String)
-    return StringField(copy(str.data), 1:length(str.data))
-end
-
-function Base.convert(::Type{UTF8String}, field::StringField)
-    return UTF8String(field.data[field.part])
+function Base.convert(::Type{Compat.UTF8String}, field::StringField)
+    return Compat.UTF8String(field.data[field.part])
 end
 
 function Base.convert(::Type{AbstractString}, field::StringField)
-    return convert(UTF8String, field::StringField)
+    return convert(Compat.UTF8String, field::StringField)
 end
 
 function Base.write(io::IO, field::StringField)
-    write(io, convert(UTF8String, field))
+    write(io, convert(Compat.UTF8String, field))
 end
 
 function Base.show(io::IO, field::StringField)
-    print(io, convert(UTF8String, field))
+    print(io, convert(Compat.UTF8String, field))
 end
 
 function Base.writemime(io::IO, T::MIME"text/plain", field::StringField)
-    writemime(io, T, convert(UTF8String, field))
+    writemime(io, T, convert(Compat.UTF8String, field))
 end
 
 function Base.copy(field::StringField)
@@ -131,13 +132,13 @@ function Base.hash(field::StringField, h::UInt64)
                  length(field.part), h % UInt32) + h
 end
 
-function Base.(:(==))(a::StringField, b::StringField)
+@compat function Base.:(==)(a::StringField, b::StringField)
     return length(a) == length(b) &&
         ccall(:memcmp, Cint, (Ptr{Void}, Ptr{Void}, Csize_t),
               pointer(a.data, a.part.start), pointer(b.data, b.part.start), length(a)) == 0
 end
 
-function Base.(:(==))(a::StringField, b::BufferedStreams.BufferedOutputStream)
+@compat function Base.:(==)(a::StringField, b::BufferedStreams.BufferedOutputStream)
     if a === b
         return true
     elseif length(a) == length(b)

--- a/src/align/Align.jl
+++ b/src/align/Align.jl
@@ -72,6 +72,7 @@ export
     hasalignment
 
 using Bio.Seq
+using Compat
 import IntervalTrees
 
 include("operations.jl")

--- a/src/align/anchors.jl
+++ b/src/align/anchors.jl
@@ -137,7 +137,7 @@ function Alignment(cigar::AbstractString, seqpos::Int=1, refpos::Int=1)
     return Alignment(anchors)
 end
 
-function Base.(:(==))(a::Alignment, b::Alignment)
+@compat function Base.:(==)(a::Alignment, b::Alignment)
     return a.anchors == b.anchors && a.firstref == b.firstref && a.lastref == b.lastref
 end
 

--- a/src/align/models.jl
+++ b/src/align/models.jl
@@ -91,8 +91,8 @@ function AffineGapScoreModel{T}(submat::AbstractMatrix{T}; gaps...)
     return AffineGapScoreModel(SubstitutionMatrix(submat); gaps...)
 end
 
-# easy interface
-function Base.call(::Type{AffineGapScoreModel}; scores...)
+# handy interface
+function AffineGapScoreModel(; scores...)
     scores = Dict(scores)
     match = scores[:match]
     mismatch = scores[:mismatch]
@@ -190,7 +190,8 @@ function CostModel{T}(submat::AbstractMatrix{T}; indels...)
     return CostModel(SubstitutionMatrix(submat); indels...)
 end
 
-function Base.call(::Type{CostModel}; costs...)
+# handy interface
+function CostModel(; costs...)
     costs = Dict(costs)
     match = costs[:match]
     mismatch = costs[:mismatch]

--- a/src/align/pairwise/algorithms/banded_needleman_wunsch.jl
+++ b/src/align/pairwise/algorithms/banded_needleman_wunsch.jl
@@ -16,20 +16,22 @@ type BandedNeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     E::Vector{T}
     lower::Int
     upper::Int
-end
 
-function Base.call{T}(::Type{BandedNeedlemanWunsch{T}}, m, n, lower, upper)
-    lower = min(lower, m)
-    upper = min(upper, n)
-    width = lower + upper + 1
-    trace = Matrix{Trace}(width, n + 1)
-    H = Vector{T}(width)
-    E = Vector{T}(width)
-    return BandedNeedlemanWunsch(trace, H, E, lower, upper)
-end
+    function BandedNeedlemanWunsch(
+            m::Integer, n::Integer,
+            lower::Integer, upper::Integer)
+        lower = min(lower, m)
+        upper = min(upper, n)
+        width = lower + upper + 1
+        trace = Matrix{Trace}(width, n + 1)
+        H = Vector{T}(width)
+        E = Vector{T}(width)
+        return new(trace, H, E, lower, upper)
+    end
 
-function Base.call{T}(::Type{BandedNeedlemanWunsch{T}})
-    return BandedNeedlemanWunsch{T}(0, 0, 0, 0)
+    function BandedNeedlemanWunsch()
+        return BandedNeedlemanWunsch{T}(0, 0, 0, 0)
+    end
 end
 
 function ensureroom!(nw::BandedNeedlemanWunsch, m, n, lower, upper)

--- a/src/align/pairwise/algorithms/needleman_wunsch.jl
+++ b/src/align/pairwise/algorithms/needleman_wunsch.jl
@@ -10,18 +10,18 @@ type NeedlemanWunsch{T<:Union{Signed,AbstractFloat}}
     trace::Matrix{Trace}
     H::Vector{T}
     E::Vector{T}
-end
 
-function Base.call{T}(::Type{NeedlemanWunsch{T}}, m, n)
-    trace = Matrix{Trace}(m + 1, n + 1)
-    fill!(trace, 0xff)
-    H = Vector{T}(m + 1)
-    E = Vector{T}(m)
-    return NeedlemanWunsch(trace, H, E)
-end
+    function NeedlemanWunsch(m::Integer, n::Integer)
+        trace = Matrix{Trace}(m + 1, n + 1)
+        fill!(trace, 0xff)
+        H = Vector{T}(m + 1)
+        E = Vector{T}(m)
+        return new(trace, H, E)
+    end
 
-function Base.call{T}(::Type{NeedlemanWunsch{T}})
-    return NeedlemanWunsch{T}(0, 0)
+    function NeedlemanWunsch()
+        return NeedlemanWunsch{T}(m, n)
+    end
 end
 
 function ensureroom!(nw::NeedlemanWunsch, m, n)

--- a/src/align/pairwise/algorithms/smith_waterman.jl
+++ b/src/align/pairwise/algorithms/smith_waterman.jl
@@ -10,18 +10,18 @@ type SmithWaterman{T<:Union{Signed,AbstractFloat}}
     trace::Matrix{Trace}
     H::Vector{T}
     E::Vector{T}
-end
 
-function Base.call{T}(::Type{SmithWaterman{T}}, m, n)
-    trace = Matrix{Trace}(m + 1, n + 1)
-    fill!(trace, 0xff)
-    H = Vector{T}(m + 1)
-    E = Vector{T}(m)
-    return SmithWaterman(trace, H, E)
-end
+    function SmithWaterman(m::Integer, n::Integer)
+        trace = Matrix{Trace}(m + 1, n + 1)
+        fill!(trace, 0xff)
+        H = Vector{T}(m + 1)
+        E = Vector{T}(m)
+        return new(trace, H, E)
+    end
 
-function Base.call{T}(::Type{SmithWaterman{T}})
-    return SmithWaterman{T}(0, 0)
+    function SmithWaterman()
+        return SmithWaterman{T}(0, 0)
+    end
 end
 
 function ensureroom!(sw::SmithWaterman, m, n)

--- a/src/align/pairwise/result.jl
+++ b/src/align/pairwise/result.jl
@@ -21,7 +21,7 @@ function PairwiseAlignmentResult(value, isscore, seq, ref)
                                    Nullable(PairwiseAlignment(seq, ref)))
 end
 
-function Base.call{S1,S2}(::Type{PairwiseAlignmentResult{S1,S2}}, value, isscore)
+@compat function (::Type{PairwiseAlignmentResult{S1,S2}}){S1,S2}(value, isscore)
     return PairwiseAlignmentResult(value, isscore,
                                    Nullable{PairwiseAlignment{S1,S2}}())
 end

--- a/src/align/submat.jl
+++ b/src/align/submat.jl
@@ -100,7 +100,7 @@ Base.maximum(submat::SubstitutionMatrix) = maximum(submat.data)
 
 function Base.show{T,S}(io::IO, submat::SubstitutionMatrix{T,S})
     n = size(submat.data, 1)
-    mat = Matrix{UTF8String}(n, n)
+    mat = Matrix{Compat.String}(n, n)
     for i in 1:n, j in 1:n
         mat[i,j] = string(submat.data[i,j])
         if !submat.defined[i,j]

--- a/src/intervals/Intervals.jl
+++ b/src/intervals/Intervals.jl
@@ -36,7 +36,8 @@ using
     BufferedStreams,
     IntervalTrees,
     Libz,
-    Colors
+    Colors,
+    Compat
 
 using Base.Collections:
     heappush!,

--- a/src/intervals/bed.jl
+++ b/src/intervals/bed.jl
@@ -35,7 +35,7 @@ function Base.copy(metadata::BEDMetadata)
         metadata.block_firsts[1:metadata.block_count])
 end
 
-function Base.(:(==))(a::BEDMetadata, b::BEDMetadata)
+@compat function Base.:(==)(a::BEDMetadata, b::BEDMetadata)
     if a.used_fields != b.used_fields
         return false
     end

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -86,7 +86,7 @@ function precedes{T}(a::Interval{T}, b::Interval{T},
         seqname_isless(a.seqname, b.seqname)::Bool
 end
 
-function Base.(:(==)){T}(a::Interval{T}, b::Interval{T})
+@compat function Base.:(==){T}(a::Interval{T}, b::Interval{T})
     return a.seqname  == b.seqname &&
            a.first    == b.first &&
            a.last     == b.last &&

--- a/src/intervals/intervalcollection.jl
+++ b/src/intervals/intervalcollection.jl
@@ -293,7 +293,7 @@ immutable IntervalCollectionStreamIteratorState{S, TS, TV}
     end
 end
 
-function Base.(:(==)){T}(a::IntervalCollection{T}, b::IntervalCollection{T})
+@compat function Base.:(==){T}(a::IntervalCollection{T}, b::IntervalCollection{T})
     if length(a) != length(b)
         return false
     end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -4,14 +4,18 @@
 # Parser
 # ------
 
-precompile(Base.open, (ASCIIString, Type{Seq.FASTA},))
+if VERSION < v"0.5-"
+    precompile(Base.open, (ASCIIString, Type{Seq.FASTA},))
+    precompile(Base.open, (ASCIIString, Type{Seq.FASTQ},))
+    precompile(Base.open, (ASCIIString, Type{Intervals.BED},))
+else
+    precompile(Base.open, (String, Type{Seq.FASTA},))
+    precompile(Base.open, (String, Type{Seq.FASTQ},))
+    precompile(Base.open, (String, Type{Intervals.BED},))
+end
 precompile(Base.read, (Seq.FASTAParser{Seq.BioSequence},))
 precompile(Base.read, (Seq.FASTAParser{Seq.DNASequence},))
 precompile(Base.read, (Seq.FASTAParser{Seq.RNASequence},))
 precompile(Base.read, (Seq.FASTAParser{Seq.AminoAcidSequence},))
-
-precompile(Base.open, (ASCIIString, Type{Seq.FASTQ},))
 precompile(Base.read, (Seq.FASTQParser{Seq.DNASequence},))
-
-precompile(Base.open, (ASCIIString, Type{Intervals.BED},))
 precompile(Base.read, (Intervals.BEDParser,))

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -186,12 +186,16 @@ include("fastq-parser.jl")
 # DEPRECATED: defined just for compatibility
 type NucleotideSequence{T<:Nucleotide} end
 
-Base.call(::Type{NucleotideSequence{DNANucleotide}}) = DNASequence()
-Base.call(::Type{NucleotideSequence{RNANucleotide}}) = RNASequence()
-Base.call(::Type{NucleotideSequence}, ::Type{DNANucleotide}) = DNASequence()
-Base.call(::Type{NucleotideSequence}, ::Type{RNANucleotide}) = RNASequence()
-Base.call(::Type{NucleotideSequence{DNANucleotide}}, seq::Union{AbstractVector{DNANucleotide},AbstractString}) = DNASequence(seq)
-Base.call(::Type{NucleotideSequence{RNANucleotide}}, seq::Union{AbstractVector{RNANucleotide},AbstractString}) = RNASequence(seq)
+NucleotideSequence(::Type{DNANucleotide}) = DNASequence()
+NucleotideSequence(::Type{RNANucleotide}) = RNASequence()
+@compat begin
+    (::Type{NucleotideSequence{DNANucleotide}})() = DNASequence()
+    (::Type{NucleotideSequence{RNANucleotide}})() = RNASequence()
+    (::Type{NucleotideSequence{DNANucleotide}})(
+        seq::Union{AbstractVector{DNANucleotide},AbstractString}) = DNASequence(seq)
+    (::Type{NucleotideSequence{RNANucleotide}})(
+        seq::Union{AbstractVector{RNANucleotide},AbstractString}) = RNASequence(seq)
+end
 
 Base.convert(::Type{NucleotideSequence}, seq::DNAKmer) = DNASequence(seq)
 Base.convert(::Type{NucleotideSequence}, seq::RNAKmer) = RNASequence(seq)

--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -87,7 +87,7 @@ immutable EncodeError{A<:Alphabet,T} <: Exception
     val::T
 end
 
-Base.call{A,T}(::Type{EncodeError{A}}, val::T) = EncodeError{A,T}(val)
+EncodeError{A,T}(::Type{A}, val::T) = EncodeError{A,T}(val)
 
 function Base.showerror{A}(io::IO, err::EncodeError{A})
     print(io, "cannot encode ", err.val, " in ", A)
@@ -102,7 +102,7 @@ immutable DecodeError{A<:Alphabet,T} <: Exception
     val::T
 end
 
-Base.call{A,T}(::Type{DecodeError{A}}, val::T) = DecodeError{A,T}(val)
+DecodeError{A,T}(::Type{A}, val::T) = DecodeError{A,T}(val)
 
 function Base.showerror{A}(io::IO, err::DecodeError{A})
     print(io, "cannot decode ", err.val, " in ", A)
@@ -120,13 +120,13 @@ for (A, T, U, ub) in [
     @eval begin
         @inline function encode(::Type{$A}, x::$T)
             if x > $ub
-                throw(EncodeError{$A}(x))
+                throw(EncodeError($A, x))
             end
             return reinterpret($U, x)
         end
         @inline function decode(::Type{$A}, x::$U)
             if x > $(reinterpret(U, ub))
-                throw(DecodeError{$A}(x))
+                throw(DecodeError($A, x))
             end
             return reinterpret($T, x)
         end

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -71,7 +71,7 @@ for (aa, doc, code) in [
         ('J', "Leucine or Isoleucine",             0x17),  # ambiguous
         ('Z', "Glutamine or Glutamic Acid",        0x18),  # ambiguous
         ('X', "Unspecified or Unknown Amino Acid", 0x19)]  # ambiguous
-    var = symbol("AA_", aa)
+    var = Symbol("AA_", aa)
     @eval begin
         @doc $doc const $var = convert(AminoAcid, $code)
         char_to_aa[$(Int(aa)+1)] = char_to_aa[$(Int(lowercase(aa))+1)] = $var

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -24,10 +24,12 @@ Base.convert{T<:Number}(::Type{AminoAcid}, aa::T) = convert(AminoAcid, UInt8(aa)
 
 # These methods are necessary when deriving some algorithims
 # like iteration, sort, comparison, and so on.
-Base.(:-)(x::AminoAcid, y::AminoAcid) = Int(x) - Int(y)
-Base.(:-)(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) - UInt8(y))
-Base.(:+)(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) + UInt8(y))
-Base.(:+)(x::Integer, y::AminoAcid) = y + x
+@compat begin
+    Base.:-(x::AminoAcid, y::AminoAcid) = Int(x) - Int(y)
+    Base.:-(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) - UInt8(y))
+    Base.:+(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) + UInt8(y))
+    Base.:+(x::Integer, y::AminoAcid) = y + x
+end
 Base.isless(x::AminoAcid, y::AminoAcid) = isless(UInt8(x), UInt8(y))
 
 

--- a/src/seq/eachkmer.jl
+++ b/src/seq/eachkmer.jl
@@ -46,6 +46,10 @@ eachkmer{A<:RNAAlphabet}(seq::BioSequence{A}, K::Integer, step::Integer=1) = eac
 
 Base.eltype{T,k,S}(::Type{EachKmerIterator{T,k,S}}) = Tuple{Int,Kmer{T,k}}
 
+if VERSION > v"0.5-"
+    Base.iteratorsize(::EachKmerIterator) = Base.SizeUnknown()
+end
+
 @inline function Base.start{T,K}(it::EachKmerIterator{T,K})
     nextn = find_next_ambiguous(it.seq, it.seq.part.start)
     pair = Nullable{Tuple{Int,Kmer{T,K}}}()

--- a/src/seq/fasta.jl
+++ b/src/seq/fasta.jl
@@ -17,7 +17,7 @@ function FASTAMetadata()
     return FASTAMetadata(StringField())
 end
 
-function Base.(:(==))(a::FASTAMetadata, b::FASTAMetadata)
+@compat function Base.:(==)(a::FASTAMetadata, b::FASTAMetadata)
     return a.description == b.description
 end
 

--- a/src/seq/fastq.jl
+++ b/src/seq/fastq.jl
@@ -23,7 +23,7 @@ function FASTQMetadata()
     return FASTQMetadata(StringField(), Int8[])
 end
 
-function Base.(:(==))(a::FASTQMetadata, b::FASTQMetadata)
+@compat function Base.:(==)(a::FASTQMetadata, b::FASTQMetadata)
     return a.description == b.description && a.quality == b.quality
 end
 

--- a/src/seq/geneticcode.jl
+++ b/src/seq/geneticcode.jl
@@ -102,7 +102,7 @@ macro register_ncbi_gencode(id, bind, tbl)
         gencode = parse_gencode($tbl)
         const $(esc(bind)) = gencode
         ncbi_trans_table.tables[$id] = gencode
-        ncbi_trans_table.bindings[$id] = symbol($(string(bind)))
+        ncbi_trans_table.bindings[$id] = Symbol($(string(bind)))
     end
 end
 

--- a/src/seq/geneticcode.jl
+++ b/src/seq/geneticcode.jl
@@ -9,7 +9,7 @@
 # A genetic code is a table mapping RNA 3-mers (i.e. RNAKmer{3}) to AminoAcids.
 "Type representing a Genetic Code"
 immutable GeneticCode <: Associative{RNAKmer{3}, AminoAcid}
-    name::ASCIIString
+    name::Compat.String
     tbl::Vector{AminoAcid}
 end
 
@@ -325,9 +325,7 @@ function translate(seq::RNASequence;
     return translate(seq, code, allow_ambiguous_codons)
 end
 
-function translate(seq::RNASequence,
-                   code::GeneticCode=standard_genetic_code,
-                   allow_ambiguous_codons::Bool=true)
+function translate(seq::RNASequence, code::GeneticCode, allow_ambiguous_codons::Bool)
     aaseqlen, r = divrem(length(seq), 3)
     if r != 0
         error("RNASequence length is not divisible by three. Cannot translate.")

--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -137,8 +137,8 @@ end
 # ---------------
 
 for (A, N) in ((DNAAlphabet, DNANucleotide), (RNAAlphabet, RNANucleotide))
-    @eval begin
-        function Base.(:(==)){A<:$A,K}(a::BioSequence{A}, b::Kmer{$N,K})
+    @compat @eval begin
+        function Base.:(==){A<:$A,K}(a::BioSequence{A}, b::Kmer{$N,K})
             if length(a) != K
                 return false
             end
@@ -149,7 +149,7 @@ for (A, N) in ((DNAAlphabet, DNANucleotide), (RNAAlphabet, RNANucleotide))
             end
             return true
         end
-        Base.(:(==)){A<:$A,K}(a::Kmer{$N,K}, b::BioSequence{A}) = b == a
+        Base.:(==){A<:$A,K}(a::Kmer{$N,K}, b::BioSequence{A}) = b == a
     end
 end
 
@@ -187,9 +187,11 @@ function Base.showcompact{T,k}(io::IO, x::Kmer{T,k})
     end
 end
 
-Base.(:-){T,K}(x::Kmer{T,K}, y::Integer)   = Kmer{T,K}(UInt64(x) - reinterpret(UInt64, y))
-Base.(:+){T,K}(x::Kmer{T,K}, y::Integer)   = Kmer{T,K}(UInt64(x) + reinterpret(UInt64, y))
-Base.(:+){T,K}(x::Integer,   y::Kmer{T,K}) = y + x
+@compat begin
+    Base.:-{T,K}(x::Kmer{T,K}, y::Integer) = Kmer{T,K}(UInt64(x) - reinterpret(UInt64, y))
+    Base.:+{T,K}(x::Kmer{T,K}, y::Integer) = Kmer{T,K}(UInt64(x) + reinterpret(UInt64, y))
+    Base.:+{T,K}(x::Integer, y::Kmer{T,K}) = y + x
+end
 Base.isless{T,K}(x::Kmer{T,K}, y::Kmer{T,K}) = isless(UInt64(x), UInt64(y))
 
 Base.length{T, K}(x::Kmer{T, K}) = K

--- a/src/seq/kmercounts.jl
+++ b/src/seq/kmercounts.jl
@@ -39,7 +39,7 @@ end
 function Base.show{T,K}(io::IO, counts::KmerCounts{T,K})
     println(io, (T == DNANucleotide ? "DNA" : "RNA"), "KmerCounts{", K, "}:")
     for x in UInt64(1):UInt64(4^K)
-        s = ASCIIString(Kmer{T,K}(x - 1))
+        s = string(Kmer{T,K}(x - 1))
         println(io, "  ", s, " => ", counts.data[x])
     end
 end

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -28,10 +28,12 @@ Base.convert{T<:Number,S<:Nucleotide}(::Type{S}, nt::T) = convert(S, UInt8(nt))
 
 # These methods are necessary when deriving some algorithims
 # like iteration, sort, comparison, and so on.
-Base.(:-){N<:Nucleotide}(x::N, y::N) = Int(x) - Int(y)
-Base.(:-){N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) - UInt8(y))
-Base.(:+){N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) + UInt8(y))
-Base.(:+){N<:Nucleotide}(x::Integer, y::N) = y + x
+@compat begin
+    Base.:-{N<:Nucleotide}(x::N, y::N) = Int(x) - Int(y)
+    Base.:-{N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) - UInt8(y))
+    Base.:+{N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) + UInt8(y))
+    Base.:+{N<:Nucleotide}(x::Integer, y::N) = y + x
+end
 Base.isless{N<:Nucleotide}(x::N, y::N) = isless(UInt8(x), UInt8(y))
 
 

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -69,7 +69,7 @@ for (code, (nt, doc, compat)) in enumerate([
         ('D', "DNA Adenine, Guanine or Thymine",           0b1101),
         ('B', "DNA Cytosine, Guanine or Thymine",          0b1110),
         ('N', "DNA Adenine, Cytosine, Guanine or Thymine", 0b1111)])
-    var = symbol("DNA_", nt)
+    var = Symbol("DNA_", nt)
     @eval begin
         @doc $doc const $var = convert(DNANucleotide, $(UInt8(code - 1)))
         char_to_dna[$(Int(nt + 1))] = char_to_dna[$(Int(lowercase(nt) + 1))] = $var
@@ -124,7 +124,7 @@ for (code, (nt, doc)) in enumerate([
         ('D', "RNA Adenine, Guanine or Uracil"          ),
         ('B', "RNA Cytosine, Guanine or Uracil"         ),
         ('N', "RNA Adenine, Cytosine, Guanine or Uracil")])
-    var = symbol("RNA_", nt)
+    var = Symbol("RNA_", nt)
     @eval begin
         @doc $doc const $var = convert(RNANucleotide, $(UInt8(code - 1)))
         char_to_rna[$(Int(nt + 1))] = char_to_rna[$(Int(lowercase(nt) + 1))] = $var

--- a/src/seq/quality.jl
+++ b/src/seq/quality.jl
@@ -12,11 +12,11 @@ bitstype 16 QualityEncoding
 Base.convert(::Type{QualityEncoding}, nt::UInt16) = reinterpret(QualityEncoding, nt)
 Base.convert(::Type{UInt16}, nt::QualityEncoding) = reinterpret(UInt16, nt)
 
-function Base.(:|)(a::QualityEncoding, b::QualityEncoding)
+@compat function Base.:|(a::QualityEncoding, b::QualityEncoding)
     return convert(QualityEncoding, convert(UInt16, a) | convert(UInt16, b))
 end
 
-function Base.(:&)(a::QualityEncoding, b::QualityEncoding)
+@compat function Base.:&(a::QualityEncoding, b::QualityEncoding)
     return convert(QualityEncoding, convert(UInt16, a) & convert(UInt16, b))
 end
 

--- a/src/seq/seqrecord.jl
+++ b/src/seq/seqrecord.jl
@@ -39,7 +39,7 @@ function Base.getindex(seqrec::SeqRecord, r::UnitRange)
     return SeqRecord(seqrec.name, seqrec.seq[r], seqrec.metadata)
 end
 
-function Base.(:(==)){T <: SeqRecord}(a::T, b::T)
+@compat function Base.:(==){T<:SeqRecord}(a::T, b::T)
     return a.name == b.name && a.seq == b.seq && a.metadata == b.metadata
 end
 

--- a/src/seq/util.jl
+++ b/src/seq/util.jl
@@ -27,4 +27,4 @@ Copy a Kmer into the user's clipboard.
 
 Useful for pasting a query sequence in web services like BLAST.
 """
-Base.clipboard(x::Kmer) = clipboard(ASCIIString(x))
+Base.clipboard(x::Kmer) = clipboard(string(x))

--- a/src/structure/Structure.jl
+++ b/src/structure/Structure.jl
@@ -1,4 +1,14 @@
+# Bio.Structure
+# =============
+#
+# Module for structural biology.
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
 module Structure
+
+using Compat
 
 include("model.jl")
 include("pdb.jl")

--- a/src/structure/model.jl
+++ b/src/structure/model.jl
@@ -1,4 +1,5 @@
-export StructuralElement,
+export
+    StructuralElement,
     AbstractAtom,
     Atom,
     DisorderedAtom,
@@ -94,17 +95,17 @@ abstract AbstractAtom <: StructuralElement
 immutable Atom <: AbstractAtom
     het_atom::Bool
     serial::Int
-    name::ASCIIString
+    name::Compat.ASCIIString
     alt_loc_id::Char
-    res_name::ASCIIString
+    res_name::Compat.ASCIIString
     chain_id::Char
     res_number::Int
     ins_code::Char
     coords::Vector{Float64}
     occupancy::Float64
     temp_fac::Float64
-    element::ASCIIString
-    charge::ASCIIString
+    element::Compat.ASCIIString
+    charge::Compat.ASCIIString
 end
 
 "A container to hold different versions of the same atom in a PDB file."
@@ -122,13 +123,13 @@ abstract AbstractResidue <: StructuralElement
 
 "A residue (amino acid) or other molecule record from a PDB file."
 immutable Residue <: AbstractResidue
-    name::ASCIIString
+    name::Compat.ASCIIString
     chain_id::Char
     number::Int
     ins_code::Char
     het_res::Bool # Does the residue consist of hetatoms?
-    atom_list::Vector{ASCIIString}
-    atoms::Dict{ASCIIString, AbstractAtom}
+    atom_list::Vector{Compat.ASCIIString}
+    atoms::Dict{Compat.ASCIIString, AbstractAtom}
 end
 
 # Constructor without atoms
@@ -147,16 +148,16 @@ Residue{T <: AbstractAtom}(atoms::Vector{T}) = Residue(
 
 "A container to hold different versions of the same residue (point mutations)."
 immutable DisorderedResidue <: AbstractResidue
-    names::Dict{ASCIIString, Residue}
-    default::ASCIIString
+    names::Dict{Compat.ASCIIString, Residue}
+    default::Compat.ASCIIString
 end
 
 
 "A chain represented in a PDB file."
 immutable Chain <: StructuralElement
     id::Char
-    res_list::Vector{ASCIIString}
-    residues::Dict{ASCIIString, AbstractResidue}
+    res_list::Vector{Compat.ASCIIString}
+    residues::Dict{Compat.ASCIIString, AbstractResidue}
 end
 
 Chain(id::Char) = Chain(id, [], Dict())
@@ -174,7 +175,7 @@ Model() = Model(1)
 
 "A container for multiple models from a PDB file."
 immutable ProteinStructure <: StructuralElement
-    name::ASCIIString
+    name::Compat.ASCIIString
     models::Dict{Int, Model}
 end
 
@@ -798,10 +799,10 @@ end
 
 # Organise a Vector{AbstractResidue} into a Vector{Chain}
 function organise{T <: AbstractResidue}(residues::Vector{T})
-    chains = Dict{Char, Dict{ASCIIString, AbstractResidue}}()
+    chains = Dict{Char, Dict{Compat.ASCIIString, AbstractResidue}}()
     for res in residues
         chain_id = chainid(res)
-        !haskey(chains, chain_id) ? chains[chain_id] = Dict{ASCIIString, AbstractResidue}() : nothing
+        !haskey(chains, chain_id) ? chains[chain_id] = Dict{Compat.ASCIIString, AbstractResidue}() : nothing
         res_id = resid(res)
         @assert !haskey(chains[chain_id], res_id) "Multiple residues with the same residue ID found - cannot organise into chains"
         chains[chain_id][res_id] = res
@@ -812,18 +813,18 @@ end
 # Organise a Vector{AbstractAtom} into a Vector{AbstractResidue}
 function organise{T <: AbstractAtom}(atoms::Vector{T})
     # Key is chain ID, value is Dict where key is residue ID and value is list of atoms
-    residues = Dict{Char, Dict{ASCIIString, Vector{AbstractAtom}}}()
+    residues = Dict{Char, Dict{Compat.ASCIIString, Vector{AbstractAtom}}}()
     # Key is chain ID, value is Dict where key is residue ID, value is Dict where key is residue name and value is list of atoms
-    disordered_residues = Dict{Char, Dict{ASCIIString, Dict{ASCIIString, Vector{AbstractAtom}}}}()
+    disordered_residues = Dict{Char, Dict{Compat.ASCIIString, Dict{Compat.ASCIIString, Vector{AbstractAtom}}}}()
     # Key is chain ID, value is Dict where key is residue ID and value is default residue name
-    defaults = Dict{Char, Dict{ASCIIString, ASCIIString}}()
+    defaults = Dict{Char, Dict{Compat.ASCIIString, Compat.ASCIIString}}()
     for atom in atoms
         # Create chain Dict if required
         chain_id = chainid(atom)
         if !haskey(residues, chain_id)
-            residues[chain_id] = Dict{ASCIIString, Vector{AbstractAtom}}()
-            disordered_residues[chain_id] = Dict{ASCIIString, Dict{ASCIIString, Vector{AbstractAtom}}}()
-            defaults[chain_id] = Dict{ASCIIString, ASCIIString}()
+            residues[chain_id] = Dict{Compat.ASCIIString, Vector{AbstractAtom}}()
+            disordered_residues[chain_id] = Dict{Compat.ASCIIString, Dict{Compat.ASCIIString, Vector{AbstractAtom}}}()
+            defaults[chain_id] = Dict{Compat.ASCIIString, Compat.ASCIIString}()
         end
         res_id = resid(atom)
         # The residue ID is not yet present
@@ -888,7 +889,7 @@ which case removes all but the default location for disordered atoms.
 """
 function formatomlist(atoms::Vector{Atom}; remove_disorder::Bool=false)
     # Key is (residue ID, residue name, atom name)
-    atom_dic = Dict{Tuple{ASCIIString, ASCIIString, ASCIIString}, AbstractAtom}()
+    atom_dic = Dict{Tuple{Compat.ASCIIString, Compat.ASCIIString, Compat.ASCIIString}, AbstractAtom}()
     for atom in atoms
         atom_id = atomid(atom)
         # The atom does not exist so we can create it
@@ -979,9 +980,9 @@ hetatomselector(atom::AbstractAtom) = ishetatom(atom)
 Determines if an `AbstractAtom` has its atom name in the given `Set` or
 `Vector`.
 """
-atomnameselector(atom::AbstractAtom, atom_names::Set{ASCIIString}) = atomname(atom) in atom_names
+atomnameselector(atom::AbstractAtom, atom_names::Set{Compat.ASCIIString}) = atomname(atom) in atom_names
 # Set is faster but Vector method is retained for ease of use
-atomnameselector(atom::AbstractAtom, atom_names::Vector{ASCIIString}) = atomname(atom) in atom_names
+atomnameselector(atom::AbstractAtom, atom_names::Vector{Compat.ASCIIString}) = atomname(atom) in atom_names
 
 "`Set` of C-alpha atom names."
 const calpha_atom_names = Set(["CA"])
@@ -1011,8 +1012,8 @@ heavyatomselector(atom::AbstractAtom) = stdatomselector(atom) && !hydrogenselect
 Determines if an `AbstractResidue` or `AbstractAtom` has its resiudue name in
 the given `Set` or `Vector`.
 """
-resnameselector(element::Union{AbstractResidue, AbstractAtom}, res_names::Set{ASCIIString}) = resname(element) in res_names
-resnameselector(element::Union{AbstractResidue, AbstractAtom}, res_names::Vector{ASCIIString}) = resname(element) in res_names
+resnameselector(element::Union{AbstractResidue, AbstractAtom}, res_names::Set{Compat.ASCIIString}) = resname(element) in res_names
+resnameselector(element::Union{AbstractResidue, AbstractAtom}, res_names::Vector{Compat.ASCIIString}) = resname(element) in res_names
 
 "`Set` of residue names corresponding to water."
 const water_res_names = Set(["HOH"])

--- a/src/structure/pdb.jl
+++ b/src/structure/pdb.jl
@@ -17,9 +17,9 @@ immutable PDB <: FileFormat end
 
 "Error arising from parsing a PDB file."
 type PDBParseError <: Exception
-    message::ASCIIString
+    message::Compat.ASCIIString
     line_number::Int
-    line::ASCIIString
+    line::Compat.ASCIIString
 end
 
 
@@ -98,14 +98,14 @@ end
 
 
 "Parse a PDB ATOM or HETATM record and return an `Atom`."
-function parseatomrecord(line::ASCIIString, line_number::Integer=1)
+function parseatomrecord(line::Compat.ASCIIString, line_number::Integer=1)
     @assert startswith(line, "ATOM  ") || startswith(line, "HETATM") "Line does not appear to be an ATOM/HETATM record: \"$line\""
     return Atom(
         line[1:6] == "HETATM",
         parsestrict(line, (7,11), Int, "Could not read atom serial number", line_number),
-        strip(parsestrict(line, (13,16), ASCIIString, "Could not read atom name", line_number)),
+        strip(parsestrict(line, (13,16), Compat.ASCIIString, "Could not read atom name", line_number)),
         parsestrict(line, (17,17), Char, "Could not read alt loc identifier", line_number),
-        strip(parsestrict(line, (18,20), ASCIIString, "Could not read residue name", line_number)),
+        strip(parsestrict(line, (18,20), Compat.ASCIIString, "Could not read residue name", line_number)),
         parsestrict(line, (22,22), Char, "Could not read chain ID", line_number),
         parsestrict(line, (23,26), Int, "Could not read residue number", line_number),
         parsestrict(line, (27,27), Char, "Could not read insertion code", line_number),
@@ -116,14 +116,14 @@ function parseatomrecord(line::ASCIIString, line_number::Integer=1)
         ],
         parselenient(line, (55,60), Float64, 1.0),
         parselenient(line, (61,66), Float64, 0.0),
-        strip(parselenient(line, (77,78), ASCIIString, "")),
-        strip(parselenient(line, (79,80), ASCIIString, ""))
+        strip(parselenient(line, (77,78), Compat.ASCIIString, "")),
+        strip(parselenient(line, (79,80), Compat.ASCIIString, ""))
     )
 end
 
 
 "Parse columns from a line and return the value or throw a `PDBParseError`."
-function parsestrict(line::ASCIIString,
+function parsestrict(line::Compat.ASCIIString,
                     cols::Tuple{Integer, Integer},
                     out_type::Type,
                     error_message::AbstractString,
@@ -137,7 +137,7 @@ end
 
 
 "Parse columns from a line and return the value or a default value."
-function parselenient(line::ASCIIString,
+function parselenient(line::Compat.ASCIIString,
                     cols::Tuple{Integer, Integer},
                     out_type::Type,
                     default)
@@ -150,13 +150,13 @@ end
 
 
 "Parse columns from a line."
-function parsevalue(line::ASCIIString, cols::Tuple{Integer, Integer}, out_type::Type)
+function parsevalue(line::Compat.ASCIIString, cols::Tuple{Integer, Integer}, out_type::Type)
     try
         if out_type == Int
             return parse(Int, line[cols[1]:cols[2]])
         elseif out_type == Float64
             return parse(Float64, line[cols[1]:cols[2]])
-        elseif out_type == ASCIIString
+        elseif out_type == Compat.ASCIIString
             return line[cols[1]:cols[2]]
         elseif out_type == Char
             return line[cols[1]]
@@ -208,7 +208,7 @@ end
 
 
 "Form a Protein Data Bank (PDB) format ATOM or HETATM record from an `Atom`."
-pdbline(atom::Atom) = ASCIIString[
+pdbline(atom::Atom) = Compat.ASCIIString[
         ishetatom(atom) ? "HETATM" : "ATOM  ",
         spacestring(serial(atom), 5),
         " ",

--- a/src/tools/blast/Blast.jl
+++ b/src/tools/blast/Blast.jl
@@ -1,13 +1,14 @@
 module Blast
 
-using Bio.Seq,
-      Bio.Align,
-      LightXML
-
 export blastn,
        blastp,
        readblastXML,
        BlastResult
+
+using Bio.Seq,
+      Bio.Align,
+      LightXML,
+      Compat
 
 include("blastcommandline.jl")
 

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -9,14 +9,15 @@
 immutable BlastResult
     bitscore::Float64
     expect::Float64
-    queryname::ASCIIString
-    hitname::ASCIIString
+    queryname::Compat.String
+    hitname::Compat.String
     hit::BioSequence
     alignment::AlignedSequence
 end
 
 """
-`readblastXML(blastrun::ASCIIString)`
+    readblastXML(blastrun::AbstractString)
+
 Parse XML output of a blast run. Input is an XML string eg:
 ```julia
 results = readall(open("blast_results.xml")) # need to use `readstring` instead of `readall` for v0.5
@@ -25,7 +26,7 @@ readblastXML(results)
 
 Returns Vector{BlastResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
 """
-function readblastXML(blastrun::ASCIIString; seqtype="nucl")
+function readblastXML(blastrun::AbstractString; seqtype="nucl")
     xdoc = parse_string(blastrun)
     xroot = root(xdoc)
     params = get_elements_by_tagname(xroot, "BlastOutput_param")

--- a/src/util/indexing.jl
+++ b/src/util/indexing.jl
@@ -11,6 +11,7 @@ module Indexing
 export
     Indexer, names!, rename!, rename
 
+using Compat
 
 """
 The Indexer type
@@ -208,7 +209,7 @@ end
 Base.length(x::Indexer) = length(x.names)
 Base.names(x::Indexer) = copy(x.names)
 Base.copy(x::Indexer) = Indexer(copy(x.lookup), copy(x.names))
-Base.(:(==))(x::Indexer, y::Indexer) = (x.lookup == y.lookup) && (x.names == y.names)
+@compat Base.:(==)(x::Indexer, y::Indexer) = (x.lookup == y.lookup) && (x.names == y.names)
 Base.haskey(x::Indexer, key::Symbol) = haskey(x.lookup, key)
 Base.haskey(x::Indexer, key::AbstractString) = haskey(x, convert(Symbol, key))
 Base.haskey(x::Indexer, key::Integer) = 1 <= key <= length(x.names)

--- a/src/util/indexing.jl
+++ b/src/util/indexing.jl
@@ -191,7 +191,7 @@ function make_unique(names::Vector{Symbol})
         nm = names[i]
         k = 1
         while true
-            newnm = symbol("$(nm)_$k")
+            newnm = Symbol("$(nm)_$k")
             if !in(newnm, seen)
                 warn("Trying to build an index with duplicate names. Changing $(names[i]) to $(newnm)")
                 names[i] = newnm

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -12,6 +12,7 @@ export eachwindow,
     EachWindowIterator,
     missed
 
+using Compat
 using Bio.Seq:
     Sequence
 
@@ -38,6 +39,7 @@ immutable EachWindowIterator{T <: ArrayOrStringOrSeq}
     end
 end
 
+
 """
 Calculate the number of windows that will result from iterating across the container.
 
@@ -62,7 +64,7 @@ A sliding window iterator is considered equal to another
 sliding window iterator if the data is considered equal, and the
 width and step of the iterator is also equivalent.
 """
-function Base.(:(==))(x::EachWindowIterator, y::EachWindowIterator)
+@compat function Base.:(==)(x::EachWindowIterator, y::EachWindowIterator)
     return (x.data == y.data) && (x.width == y.width) && (x.step == y.step)
 end
 

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -217,7 +217,7 @@ end
 
 
 # generate test cases from two aligned sequences
-function alnscore{S,T}(::Type{S}, affinegap::AffineGapScoreModel{T}, alnstr::ASCIIString, clip::Bool)
+function alnscore{S,T}(::Type{S}, affinegap::AffineGapScoreModel{T}, alnstr::AbstractString, clip::Bool)
     gap_open = affinegap.gap_open
     gap_extend = affinegap.gap_extend
     lines = split(chomp(alnstr), '\n')
@@ -262,11 +262,11 @@ function alnscore{S,T}(::Type{S}, affinegap::AffineGapScoreModel{T}, alnstr::ASC
     return sa, sb, score, clip ? string(a[start:stop], '\n', b[start:stop]) : string(a, '\n', b)
 end
 
-function alnscore{T}(affinegap::AffineGapScoreModel{T}, alnstr::ASCIIString; clip=true)
-    return alnscore(ASCIIString, affinegap, alnstr, clip)
+function alnscore{T}(affinegap::AffineGapScoreModel{T}, alnstr::AbstractString; clip=true)
+    return alnscore(AbstractString, affinegap, alnstr, clip)
 end
 
-function alndistance{S,T}(::Type{S}, cost::CostModel{T}, alnstr::ASCIIString)
+function alndistance{S,T}(::Type{S}, cost::CostModel{T}, alnstr::AbstractString)
     lines = split(chomp(alnstr), '\n')
     @assert length(lines) == 2
     a, b = lines
@@ -285,8 +285,8 @@ function alndistance{S,T}(::Type{S}, cost::CostModel{T}, alnstr::ASCIIString)
     return S(replace(a, r"\s|-", "")), S(replace(b, r"\s|-", "")), dist
 end
 
-function alndistance{T}(cost::CostModel{T}, alnstr::ASCIIString)
-    return alndistance(ASCIIString, cost, alnstr)
+function alndistance{T}(cost::CostModel{T}, alnstr::AbstractString)
+    return alndistance(AbstractString, cost, alnstr)
 end
 
 function alignedpair(alnres)

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -7,7 +7,7 @@ else
     const Test = BaseTestNext
 end
 
-import Bio
+import Compat
 using Bio.Seq,
     YAML,
     TestFunctions
@@ -85,7 +85,7 @@ function dna_complement(seq::AbstractString)
             seqc[i] = seq[i]
         end
     end
-    return convert(ASCIIString, seqc)
+    return convert(AbstractString, seqc)
 end
 
 function rna_complement(seq::AbstractString)
@@ -103,7 +103,7 @@ function rna_complement(seq::AbstractString)
             seqc[i] = seq[i]
         end
     end
-    return convert(ASCIIString, seqc)
+    return convert(AbstractString, seqc)
 end
 
 function random_interval(minstart, maxstop)
@@ -286,8 +286,8 @@ end
 
     @testset "Encoder" begin
         @testset "DNA" begin
-            encode = Bio.Seq.encode
-            EncodeError = Bio.Seq.EncodeError
+            encode = Seq.encode
+            EncodeError = Seq.EncodeError
 
             # 2 bits
             @test encode(DNAAlphabet{2}, DNA_A) === convert(UInt8, DNA_A) === 0b00
@@ -301,11 +301,11 @@ end
             for nt in alphabet(DNANucleotide)
                 @test encode(DNAAlphabet{4}, nt) === convert(UInt8, nt)
             end
-            @test_throws EncodeError encode(DNAAlphabet{4}, Bio.Seq.DNA_INVALID)
+            @test_throws EncodeError encode(DNAAlphabet{4}, Seq.DNA_INVALID)
         end
         @testset "RNA" begin
-            encode = Bio.Seq.encode
-            EncodeError = Bio.Seq.EncodeError
+            encode = Seq.encode
+            EncodeError = Seq.EncodeError
 
             # 2 bits
             @test encode(RNAAlphabet{2}, RNA_A) === convert(UInt8, RNA_A) === 0b00
@@ -319,14 +319,14 @@ end
             for nt in alphabet(RNANucleotide)
                 @test encode(RNAAlphabet{4}, nt) === convert(UInt8, nt)
             end
-            @test_throws EncodeError encode(RNAAlphabet{4}, Bio.Seq.RNA_INVALID)
+            @test_throws EncodeError encode(RNAAlphabet{4}, Seq.RNA_INVALID)
         end
     end
 
     @testset "Decoder" begin
         @testset "DNA" begin
-            decode = Bio.Seq.decode
-            DecodeError = Bio.Seq.DecodeError
+            decode = Seq.decode
+            DecodeError = Seq.DecodeError
 
             # 2 bits
             @test decode(DNAAlphabet{2}, 0b00) === convert(DNANucleotide, 0b00) === DNA_A
@@ -343,8 +343,8 @@ end
             @test_throws DecodeError decode(DNAAlphabet{4}, 0b10000)
         end
         @testset "RNA" begin
-            decode = Bio.Seq.decode
-            DecodeError = Bio.Seq.DecodeError
+            decode = Seq.decode
+            DecodeError = Seq.DecodeError
 
             # 2 bits
             @test decode(RNAAlphabet{2}, 0b00) === convert(RNANucleotide, 0b00) === RNA_A
@@ -439,21 +439,21 @@ end
     end
 
     @testset "Encoder" begin
-        encode = Bio.Seq.encode
+        encode = Seq.encode
         @test encode(AminoAcidAlphabet, AA_A) === 0x00
         for aa in alphabet(AminoAcid)
             @test encode(AminoAcidAlphabet, aa) === convert(UInt8, aa)
         end
-        @test_throws Bio.Seq.EncodeError encode(AminoAcidAlphabet, Bio.Seq.AA_INVALID)
+        @test_throws Seq.EncodeError encode(AminoAcidAlphabet, Seq.AA_INVALID)
     end
 
     @testset "Decoder" begin
-        decode = Bio.Seq.decode
+        decode = Seq.decode
         @test decode(AminoAcidAlphabet, 0x00) === AA_A
         for x in 0x00:0x1b
             @test decode(AminoAcidAlphabet, x) === convert(AminoAcid, x)
         end
-        @test_throws Bio.Seq.DecodeError decode(AminoAcidAlphabet, 0x1c)
+        @test_throws Seq.DecodeError decode(AminoAcidAlphabet, 0x1c)
     end
 
     @testset "Parsers" begin
@@ -601,7 +601,7 @@ end
         test_conversion(RNAAlphabet{2}, RNAAlphabet{4}, "ACGU"^100)
 
         # ambiguous nucleotides cannot be stored in 2-bit encoding
-        EncodeError = Bio.Seq.EncodeError
+        EncodeError = Seq.EncodeError
         @test_throws EncodeError convert(BioSequence{DNAAlphabet{2}}, dna"AN")
         @test_throws EncodeError convert(BioSequence{RNAAlphabet{2}}, rna"AN")
     end
@@ -637,7 +637,7 @@ end
             end
             str = string([chunk[parts[i]] for (i, chunk) in enumerate(chunks)]...)
             seq = *([BioSequence{A}(chunk)[parts[i]] for (i, chunk) in enumerate(chunks)]...)
-            @test convert(ASCIIString, seq) == uppercase(str)
+            @test convert(AbstractString, seq) == uppercase(str)
         end
 
         for _ in 1:100
@@ -667,7 +667,7 @@ end
             n = rand(1:10)
             str = chunk[start:stop] ^ n
             seq = BioSequence{A}(chunk)[start:stop] ^ n
-            @test convert(ASCIIString, seq) == uppercase(str)
+            @test convert(AbstractString, seq) == uppercase(str)
         end
 
         for _ in 1:10
@@ -846,7 +846,7 @@ end
             bioseq = BioSequence{A}(seq)
             for _ in 1:100
                 part = random_interval(1, endof(seq))
-                @test convert(ASCIIString, bioseq[part]) == seq[part]
+                @test convert(AbstractString, bioseq[part]) == seq[part]
             end
         end
 
@@ -1041,27 +1041,27 @@ end
     @testset "Transformations" begin
         function test_reverse(A, seq)
             revseq = reverse(BioSequence{A}(seq))
-            @test convert(ASCIIString, revseq) == reverse(seq)
+            @test convert(AbstractString, revseq) == reverse(seq)
         end
 
         function test_dna_complement(A, seq)
             comp = Seq.complement(BioSequence{A}(seq))
-            @test convert(ASCIIString, comp) == dna_complement(seq)
+            @test convert(AbstractString, comp) == dna_complement(seq)
         end
 
         function test_rna_complement(A, seq)
             comp = Seq.complement(BioSequence{A}(seq))
-            @test convert(ASCIIString, comp) == rna_complement(seq)
+            @test convert(AbstractString, comp) == rna_complement(seq)
         end
 
         function test_dna_revcomp(A, seq)
             revcomp = reverse_complement(BioSequence{A}(seq))
-            @test convert(ASCIIString, revcomp) == reverse(dna_complement(seq))
+            @test convert(AbstractString, revcomp) == reverse(dna_complement(seq))
         end
 
         function test_rna_revcomp(A, seq)
             revcomp = reverse_complement(BioSequence{A}(seq))
-            @test convert(ASCIIString, revcomp) == reverse(rna_complement(seq))
+            @test convert(AbstractString, revcomp) == reverse(rna_complement(seq))
         end
 
         @testset "Reverse" begin
@@ -1606,27 +1606,27 @@ end
     @testset "Transformations" begin
         function test_reverse(T, seq)
             revseq = reverse(Kmer{T,length(seq)}(seq))
-            @test convert(ASCIIString, revseq) == reverse(seq)
+            @test convert(AbstractString, revseq) == reverse(seq)
         end
 
         function test_dna_complement(seq)
             comp = Seq.complement(DNAKmer{length(seq)}(seq))
-            @test convert(ASCIIString, comp) == dna_complement(seq)
+            @test convert(AbstractString, comp) == dna_complement(seq)
         end
 
         function test_rna_complement(seq)
             comp = Seq.complement(RNAKmer{length(seq)}(seq))
-            @test convert(ASCIIString, comp) == rna_complement(seq)
+            @test convert(AbstractString, comp) == rna_complement(seq)
         end
 
         function test_dna_revcomp(seq)
             revcomp = reverse_complement(DNAKmer{length(seq)}(seq))
-            @test convert(ASCIIString, revcomp) == reverse(dna_complement(seq))
+            @test convert(AbstractString, revcomp) == reverse(dna_complement(seq))
         end
 
         function test_rna_revcomp(seq)
             revcomp = reverse_complement(RNAKmer{length(seq)}(seq))
-            @test convert(ASCIIString, revcomp) == reverse(rna_complement(seq))
+            @test convert(AbstractString, revcomp) == reverse(rna_complement(seq))
         end
 
         @testset "Reverse" begin
@@ -1673,7 +1673,7 @@ end
 
     @testset "EachKmer" begin
         function string_eachkmer(seq::AbstractString, k, step)
-            kmers = ASCIIString[]
+            kmers = Compat.String[]
             i = 1
             for i in 1:step:length(seq) - k + 1
                 subseq = seq[i:i + k - 1]
@@ -1755,7 +1755,7 @@ end
 
 @testset "Translation" begin
     # crummy string translation to test against
-    standard_genetic_code_dict = Dict{ASCIIString,Char}(
+    standard_genetic_code_dict = Dict{Compat.String,Char}(
         "AAA" => 'K', "AAC" => 'N', "AAG" => 'K', "AAU" => 'N',
         "ACA" => 'T', "ACC" => 'T', "ACG" => 'T', "ACU" => 'T',
         "AGA" => 'R', "AGC" => 'S', "AGG" => 'R', "AGU" => 'S',


### PR DESCRIPTION
This suppresses 99% of deprecated warnings happen on Julia v0.5. 

- [ ] Tag and release BufferedStreams.jl including https://github.com/BioJulia/BufferedStreams.jl/pull/14.
- [ ] Tag and release IntervalTrees.jl including https://github.com/BioJulia/IntervalTrees.jl/pull/15.