### PR TITLE
Added the Dating submodule to Phylo.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -8,3 +8,4 @@ Iterators
 Libz 0.1.1
 LightGraphs
 LightXML
+Roots

--- a/src/phylo/Phylo.jl
+++ b/src/phylo/Phylo.jl
@@ -67,6 +67,6 @@ include("phylogeny.jl")
 include("node_basics.jl")
 include("branch_basics.jl")
 include("manipulation.jl")
-
+include("dating.jl")
 
 end # module Phylo

--- a/src/phylo/dating.jl
+++ b/src/phylo/dating.jl
@@ -1,0 +1,29 @@
+module Dating
+
+using Distributions, Roots
+
+export DatingEstimate, coaltime
+
+
+immutable DatingEstimate
+    five::Float64
+    fifty::Float64
+    ninetyfive::Float64
+end
+
+
+function binomzero(p0::Float64, N::Int, B::Int)
+    f(p::Float64) = cdf(Binomial(N, p), B) - p0
+    return fzero(f, 0, 1)
+end
+
+
+function coaltime(len::Int, nmut::Int, mu::Float64)
+    five = ceil(binomzero(0.05, len, nmut) / (2 * mu))
+    fifty = ceil(binomzero(0.5, len, nmut) / (2 * mu))
+    ninetyfive = ceil(binomzero(0.95, len, nmut) / (2 * mu))
+    return DatingEstimate(five, fifty, ninetyfive)
+end
+
+
+end

--- a/src/phylo/dating.jl
+++ b/src/phylo/dating.jl
@@ -4,7 +4,15 @@ using Distributions, Roots
 
 export DatingEstimate, coaltime
 
+"""
+DatingEstimate is a simple datatype to store the results of the coaltime
+function.
 
+coaltime estimates date range that may be considered a 95% confidence range in
+which the true coalsescence time between two sequences lies.
+
+The type store the 5%, 50%, and 95% values for the range.
+"""
 immutable DatingEstimate
     five::Float64
     fifty::Float64
@@ -17,7 +25,23 @@ function binomzero(p0::Float64, N::Int, B::Int)
     return fzero(f, 0, 1)
 end
 
+"""
+    coaltime(len::Int, nmut::Int, mu::Float64)
 
+Compute the coalescence time between two sequences by modelling the process of
+mutation accumulation between two sequences as a bernoulli process.
+
+This method was first described in the paper:
+Ward, B. J., & van Oosterhout, C. (2016). Hybridcheck: Software for the rapid detection, visualization and dating of recombinant regions in genome sequence data. Molecular Ecology Resources, 16(2), 534–539.
+
+len is the length of the two aligned sequences, nmut is the number of mutations
+and mu is the assumed mutation rate.
+
+# Examples
+```julia
+coaltime(50, 17, 10e-9)
+```
+"""
 function coaltime(len::Int, nmut::Int, mu::Float64)
     five = ceil(binomzero(0.05, len, nmut) / (2 * mu))
     fifty = ceil(binomzero(0.5, len, nmut) / (2 * mu))

--- a/src/phylo/dating.jl
+++ b/src/phylo/dating.jl
@@ -18,6 +18,7 @@ abstract DatingEstimate
 
 Base.print(io::IO, de::DatingEstimate) = println(io, "$(lower(de)) ... $(upper(de))")
 Base.show(io::IO, de::DatingEstimate) = println(io, "Coalesence time estimate between two sequences:\nt lies between $(lower(de)) and $(upper(de))")
+Base.in(val::Float64, de::DatingEstimate) = val <= upper(de) && val >= lower(de)
 
 # Different coalescence time estimation algorithms.
 # method coaltime is dispatched according to arguments or type of
@@ -56,8 +57,9 @@ immutable SDResult <: DatingEstimate
     upper::Float64
 end
 
+lower(x::Float64) = x
 lower(x::SDResult) = x.lower
-
+upper(c::Float64) = x
 upper(x::SDResult) = x.upper
 
 function Base.show(io::IO, de::SDResult)

--- a/src/phylo/dating.jl
+++ b/src/phylo/dating.jl
@@ -2,7 +2,8 @@ module Dating
 
 using Distributions, Roots
 
-export DatingEstimate, coaltime, SimpleEstimate, SpeedDating, SDResult
+export DatingEstimate, coaltime, SimpleEstimate, SpeedDating, SDResult, upper,
+       lower
 
 """
 An abstract dating estimate type.
@@ -36,7 +37,7 @@ coaltime(50, 17, 10e-9, SimpleEstimate)
 ```
 """
 function coaltime(len::Int, nmut::Int, mu::Float64, ::Type{SimpleEstimate})
-    return (len / nmut) / (2 * mu)
+    return (nmut / len) / (2 * mu)
 end
 
 

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -149,10 +149,17 @@ end
 end
 
 
-tests = [(10, 3), (100, 2), (1000, 37), (50000, 1023)]
-
 @testset "Dating algorithms" begin
-
+    for i in 1:10
+        size = rand(10:100)
+        mutations = rand(1:size)
+        rate = rand(10e-9:10e-10:10e-6)
+        expected = (mutations / size) / (2 * rate)
+        estimated = coaltime(size, mutations, rate)
+        print(expected)
+        print(estimated)
+        @test (expected in estimated.five:estimated.ninetyfive) == true
+    end
 end
 
 

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -156,11 +156,7 @@ end
         rate = rand(10e-9:10e-10:10e-6)
         expected = coaltime(size, mutations, rate, SimpleEstimate)
         estimated = coaltime(size, mutations, rate, SpeedDating)
-        show(expected)
-        show(estimated)
-        print(expected)
-        print(estimated)
-        @test (expected in estimated.five:estimated.ninetyfive) == true
+        @test expected in estimated
     end
 end
 

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -1,6 +1,5 @@
 module TestPhylo
 
-
 if VERSION >= v"0.5-"
     using Base.Test
 else
@@ -10,6 +9,7 @@ end
 
 using Bio.Phylo
 using LightGraphs
+using Bio.Phylo.Dating
 
 @testset "Phylogenies" begin
 
@@ -147,5 +147,13 @@ end
     @test n_possible_unrooted(4) == 3
     @test n_possible_unrooted(5) == 15
 end
+
+
+tests = [(10, 3), (100, 2), (1000, 37), (50000, 1023)]
+
+@testset "Dating algorithms" begin
+
+end
+
 
 end # TestPhylo

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -152,7 +152,7 @@ end
 @testset "Dating algorithms" begin
     for i in 1:10
         size = rand(10:100)
-        mutations = rand(1:size)
+        mutations = rand(1:(size - 1))
         rate = rand(10e-9:10e-10:10e-6)
         expected = coaltime(size, mutations, rate, SimpleEstimate)
         estimated = coaltime(size, mutations, rate, SpeedDating)

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -154,8 +154,10 @@ end
         size = rand(10:100)
         mutations = rand(1:size)
         rate = rand(10e-9:10e-10:10e-6)
-        expected = (mutations / size) / (2 * rate)
-        estimated = coaltime(size, mutations, rate)
+        expected = coaltime(size, mutations, rate, SimpleEstimate)
+        estimated = coaltime(size, mutations, rate, SpeedDating)
+        show(expected)
+        show(estimated)
         print(expected)
         print(estimated)
         @test (expected in estimated.five:estimated.ninetyfive) == true


### PR DESCRIPTION
This PR adds a Dating submodule to Phylo. Initially it contains a simple procedure I designed for a larger software project on my PhD, which returns an estimation of the coalescence time between two sequences, based on assumptions formalised by modelling mutation accumulation between sequences as a binomial process.