### PR TITLE
define eltype for Kmers

### DIFF
--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -201,6 +201,7 @@ Base.endof(x::Kmer) = length(x)
 Base.start(x::Kmer) = 1
 Base.next(x::Kmer, i::Int) = unsafe_getindex(x, i), i + 1
 Base.done(x::Kmer, i::Int) = i > length(x)
+Base.eltype{T,k}(::Type{Kmer{T,k}}) = T
 
 function Base.findnext{T}(kmer::Kmer{T}, val, start::Integer)
     checkbounds(kmer, start)


### PR DESCRIPTION
(Now I'm splitting #152 into several pull requests).

This will add `eltype` for the `Kmer` type. I believe nobody is against this change, so I will merge this soon.