### PR TITLE
SymbolRange, cyclic arithmetic, and more informative `show` method.

### DIFF
--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -179,13 +179,13 @@ julia> DNA_T - DNA_C  # difference
 
 ```
 
-Note that these operations do **not** check bounds of valid range:
+Note that these operations are cyclic:
 ```jlcon
-julia> DNA_C - 2
-Invalid DNA Nucleotide
+julia> DNA_C + 15
+A
 
-julia> DNA_A + 30
-Invalid DNA Nucleotide
+julia> DNA_A - 1
+-
 
 ```
 

--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -63,16 +63,16 @@ Symbols are accessible as constants with `DNA_` or `RNA_` prefix:
 
 ```jlcon
 julia> DNA_A
-A
+DNA_A
 
 julia> DNA_T
-T
+DNA_T
 
 julia> RNA_U
-U
+RNA_U
 
 julia> DNA_Gap
--
+DNA_Gap
 
 julia> typeof(DNA_A)
 Bio.Seq.DNANucleotide
@@ -86,7 +86,7 @@ Symbols can be constructed by converting regular characters:
 
 ```jlcon
 julia> convert(DNANucleotide, 'C')
-C
+DNA_C
 
 julia> convert(DNANucleotide, 'C') === DNA_C
 true
@@ -134,13 +134,13 @@ Set of amino acid symbols also covers IUPAC amino acid symbols plus a gap symbol
 Symbols are accessible as constants with `AA_` prefix:
 ```jlcon
 julia> AA_A
-A
+AA_A
 
 julia> AA_Q
-Q
+AA_Q
 
 julia> AA_Term
-*
+AA_Term
 
 julia> typeof(AA_A)
 Bio.Seq.AminoAcid
@@ -150,7 +150,7 @@ Bio.Seq.AminoAcid
 Symbols can be constructed by converting regular characters:
 ```jlcon
 julia> convert(AminoAcid, 'A')
-A
+AA_A
 
 julia> convert(AminoAcid, 'P') === AA_P
 true
@@ -169,10 +169,10 @@ julia> DNA_A < DNA_C < DNA_G < DNA_T  # order
 true
 
 julia> DNA_A + 1  # addition
-C
+DNA_C
 
 julia> DNA_T - 3  # subtraction
-A
+DNA_A
 
 julia> DNA_T - DNA_C  # difference
 2
@@ -182,12 +182,58 @@ julia> DNA_T - DNA_C  # difference
 Note that these operations are cyclic:
 ```jlcon
 julia> DNA_C + 15
-A
+DNA_A
 
 julia> DNA_A - 1
--
+DNA_Gap
 
 ```
+
+
+### Symbol Ranges
+
+Consecutive symbol sets can be created using a colon like integer ranges:
+```jlcon
+julia> DNA_A:DNA_T    # unambiguous DNA nucleotides (A, C, G, T)
+DNA_A:DNA_T
+
+julia> DNA_A:DNA_N    # all DNA nucleotides except gap
+DNA_A:DNA_N
+
+julia> DNA_A:DNA_Gap  # all DNA nucleotides including gap
+DNA_A:DNA_Gap
+
+julia> AA_A:AA_V      # standard amino acids
+AA_A:AA_V
+
+julia> AA_A:AA_U      # standard amino acids + pyrrolysine (O) + selenocysteine (U)
+AA_A:AA_U
+
+julia> AA_A:AA_X      # all amino acids except teminal codon (*) and gap
+AA_A:AA_X
+
+julia> AA_A:AA_Gap    # all amino acids including teminal codon (*) and gap
+AA_A:AA_Gap
+
+```
+
+Most range operations are supported, especially the iterator interface and the
+membership operator (`in` or `∈`) will be useful in many situations:
+```jlcon
+julia> for nt in DNA_A:DNA_T; println(nt); end
+A
+C
+G
+T
+
+julia> DNA_C in DNA_A:DNA_T  # DNA_C is in the range of unambiguous DNA nucleotides
+true
+
+julia> DNA_N in DNA_A:DNA_T  # DNA_N is not in it
+false
+
+```
+
 
 ### Other functions
 
@@ -282,13 +328,13 @@ julia> convert(ASCIIString, dna"TTANGTA")
 
 julia> convert(Vector{DNANucleotide}, dna"TTANGTA")
 7-element Array{Bio.Seq.DNANucleotide,1}:
- T
- T
- A
- N
- G
- T
- A
+ DNA_T
+ DNA_T
+ DNA_A
+ DNA_N
+ DNA_G
+ DNA_T
+ DNA_A
 
 ```
 
@@ -342,7 +388,7 @@ julia> seq = dna"ACGTTTANAGTNNAGTACC"
 ACGTTTANAGTNNAGTACC
 
 julia> seq[5]
-T
+DNA_T
 
 julia> seq[6:end]
 14nt DNA Sequence:
@@ -365,7 +411,7 @@ julia> subseq = seq[1:2]  # create a subsequence from `seq`
 AA
 
 julia> subseq[2] = DNA_T  # modify the second element of it
-T
+DNA_T
 
 julia> subseq  # the subsequence is modified
 2nt DNA Sequence:

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -164,6 +164,7 @@ function gap end
 
 gap(::Type{Char}) = '-'
 
+include("symbolrange.jl")
 include("nucleotide.jl")
 include("aminoacid.jl")
 include("alphabet.jl")

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -26,8 +26,9 @@ Base.convert{T<:Number}(::Type{AminoAcid}, aa::T) = convert(AminoAcid, UInt8(aa)
 # like iteration, sort, comparison, and so on.
 @compat begin
     Base.:-(x::AminoAcid, y::AminoAcid) = Int(x) - Int(y)
-    Base.:-(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) - UInt8(y))
-    Base.:+(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, UInt8(x) + UInt8(y))
+    # 0x1c is the size of the amino acid alphabet
+    Base.:-(x::AminoAcid, y::Integer) = x + mod(-y, 0x1c)
+    Base.:+(x::AminoAcid, y::Integer) = reinterpret(AminoAcid, mod((UInt8(x) + y) % UInt8, 0x1c))
     Base.:+(x::Integer, y::AminoAcid) = y + x
 end
 Base.isless(x::AminoAcid, y::AminoAcid) = isless(UInt8(x), UInt8(y))

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -107,6 +107,8 @@ char_to_aa[Int('-') + 1] = AA_Gap
 aa_to_char[0x1b+1] = '-'
 compatbits_aa[0x1b+1] = 0
 
+Base.colon(start::AminoAcid, stop::AminoAcid) = SymbolRange(start, stop)
+
 Base.isvalid(::Type{AminoAcid}, x::Integer) = 0 ≤ x ≤ 0x1b
 Base.isvalid(aa::AminoAcid) = aa ≤ AA_Gap
 isambiguous(aa::AminoAcid) = AA_B ≤ aa ≤ AA_X

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -135,11 +135,26 @@ Base.convert(::Type{Char}, aa::AminoAcid) = aa_to_char[convert(UInt8, aa) + 1]
 # ---------------
 
 function Base.show(io::IO, aa::AminoAcid)
-    if aa == AA_INVALID
-        write(io, "Invalid Amino Acid")
+    if isvalid(aa)
+        if aa == AA_Term
+            write(io, "AA_Term")
+        elseif aa == AA_Gap
+            write(io, "AA_Gap")
+        else
+            write(io, "AA_", Char(aa))
+        end
     else
-        write(io, Char(aa))
+        write(io, "Invalid Amino Acid")
     end
+    return
+end
+
+function Base.print(io::IO, aa::AminoAcid)
+    if !isvalid(aa)
+        throw(ArgumentError("invalid amino acid"))
+    end
+    write(io, Char(aa))
+    return
 end
 
 # lookup table of 20 standard amino acids

--- a/src/seq/fasta.jl
+++ b/src/seq/fasta.jl
@@ -57,7 +57,7 @@ function Base.write{T}(io::IO, seqrec::SeqRecord{T,FASTAMetadata})
     counter = 1
     len = length(seqrec.seq)
     for nt in seqrec.seq
-        show(io, nt)
+        print(io, nt)
         if counter % maxchars == 0 && counter < len
             write(io, "\n")
         end

--- a/src/seq/fastq.jl
+++ b/src/seq/fastq.jl
@@ -44,7 +44,7 @@ Show a `FASTQSeqRecord` to `io`, with graphical display of quality scores.
 function Base.show(io::IO, seqrec::FASTQSeqRecord)
     write(io, "@", seqrec.name, " ", seqrec.metadata.description, "\n")
     for c in seqrec.seq
-        show(io, c)
+        print(io, c)
     end
     write(io, '\n')
     # print quality scores as a unicode bar chart
@@ -92,7 +92,7 @@ function Base.write(io::IO, seqrec::FASTQSeqRecord;
     write(io, "\n")
 
     for c in seqrec.seq
-        show(io, c)
+        print(io, c)
     end
     write(io, "\n")
 

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -213,17 +213,35 @@ Base.convert(::Type{Char}, nt::RNANucleotide) = rna_to_char[convert(UInt8, nt) +
 # ---------------
 
 function Base.show(io::IO, nt::DNANucleotide)
-    if !isvalid(nt)
-        write(io, "Invalid DNA Nucleotide")
+    if isvalid(nt)
+        if nt == DNA_Gap
+            write(io, "DNA_Gap")
+        else
+            write(io, "DNA_", Char(nt))
+        end
     else
-        write(io, Char(nt))
+        write(io, "Invalid DNA Nucleotide")
     end
+    return
 end
 
 function Base.show(io::IO, nt::RNANucleotide)
-    if !isvalid(nt)
-        write(io, "Invalid RNA Nucleotide")
+    if isvalid(nt)
+        if nt == RNA_Gap
+            write(io, "RNA_Gap")
+        else
+            write(io, "RNA_", Char(nt))
+        end
     else
-        write(io, Char(nt))
+        write(io, "Invalid RNA Nucleotide")
     end
+    return
+end
+
+function Base.print(io::IO, nt::Nucleotide)
+    if !isvalid(nt)
+        throw(ArgumentError("nucleotide is invalid"))
+    end
+    write(io, Char(nt))
+    return
 end

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -90,6 +90,8 @@ compatbits_nuc[0b1111 + 1] = 0b0000
 nnucleotide(::Type{DNANucleotide}) = DNA_N
 invalid_nucleotide(::Type{DNANucleotide}) = DNA_INVALID
 
+Base.colon(start::DNANucleotide, stop::DNANucleotide) = SymbolRange(start, stop)
+
 Base.isvalid(::Type{DNANucleotide}, x::Integer) = 0 ≤ x < 16
 Base.isvalid(nt::DNANucleotide) = nt ≤ DNA_Gap
 isambiguous(nt::DNANucleotide) = nt > DNA_T
@@ -137,6 +139,8 @@ rna_to_char[0b1111 + 1] = '-'
 "Returns Any RNA Nucleotide (RNA_N)"
 nnucleotide(::Type{RNANucleotide}) = RNA_N
 invalid_nucleotide(::Type{RNANucleotide}) = RNA_INVALID
+
+Base.colon(start::RNANucleotide, stop::RNANucleotide) = SymbolRange(start, stop)
 
 Base.isvalid(::Type{RNANucleotide}, x::Integer) = 0 ≤ x < 16
 Base.isvalid(nt::RNANucleotide) = nt ≤ RNA_Gap

--- a/src/seq/nucleotide.jl
+++ b/src/seq/nucleotide.jl
@@ -30,8 +30,8 @@ Base.convert{T<:Number,S<:Nucleotide}(::Type{S}, nt::T) = convert(S, UInt8(nt))
 # like iteration, sort, comparison, and so on.
 @compat begin
     Base.:-{N<:Nucleotide}(x::N, y::N) = Int(x) - Int(y)
-    Base.:-{N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) - UInt8(y))
-    Base.:+{N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, UInt8(x) + UInt8(y))
+    Base.:-{N<:Nucleotide}(x::N, y::Integer) = x + (-y)
+    Base.:+{N<:Nucleotide}(x::N, y::Integer) = reinterpret(N, (UInt8(x) + y % UInt8) & 0b1111)
     Base.:+{N<:Nucleotide}(x::Integer, y::N) = y + x
 end
 Base.isless{N<:Nucleotide}(x::N, y::N) = isless(UInt8(x), UInt8(y))

--- a/src/seq/symbolrange.jl
+++ b/src/seq/symbolrange.jl
@@ -1,0 +1,66 @@
+# SymbolRange
+# ===========
+#
+# Range type of biological symbols.
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+"""
+Range type of biological symbols (especially `DNANucleotide`, `RNANucleotide`,
+and `AminoAcid`).
+"""
+immutable SymbolRange{T} <: Range{T}
+    start::UInt8
+    stop::UInt8
+
+    function SymbolRange(start::T, stop::T)
+        if start > stop
+            # normalize empty range
+            start = convert(T, 0x01)
+            stop = convert(T, 0x00)
+        end
+        return new(start, stop)
+    end
+end
+
+function SymbolRange{T}(start::T, stop::T)
+    return SymbolRange{T}(start, stop)
+end
+
+function Base.show(io::IO, r::SymbolRange)
+    show(io, first(r))
+    write(io, ':')
+    show(io, last(r))
+end
+
+
+# Iterator
+# --------
+
+Base.start(r::SymbolRange) = r.start
+Base.done(r::SymbolRange, i) = i > r.stop
+Base.next(r::SymbolRange, i) = reinterpret(eltype(r), i), i + 0x01
+
+Base.size(r::SymbolRange) = (r.stop - r.start + 1,)
+Base.first(r::SymbolRange) = convert(eltype(r), r.start)
+Base.last(r::SymbolRange) = convert(eltype(r), r.stop)
+Base.in{T}(x::T, r::SymbolRange{T}) = first(r) ≤ x ≤ last(r)
+
+
+# Indexing
+# --------
+
+function Base.getindex(r::SymbolRange, i::Integer)
+    checkbounds(r, i)
+    return convert(eltype(r), r.start + i - 1)
+end
+
+function Base.getindex{T}(r::SymbolRange{T}, ir::UnitRange)
+    checkbounds(r, ir)
+    if isempty(ir)
+        return SymbolRange(T(0x01), T(0x00))
+    else
+        return SymbolRange(r[first(ir)], r[last(ir)])
+    end
+end

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -423,6 +423,20 @@ end
         end
     end
 
+    @testset "Range" begin
+        @test   DNA_A in DNA_A:DNA_G
+        @test   DNA_C in DNA_A:DNA_G
+        @test   DNA_G in DNA_A:DNA_G
+        @test !(DNA_T in DNA_A:DNA_G)
+        @test collect(DNA_C:DNA_T) == [DNA_C, DNA_G, DNA_T]
+
+        @test   RNA_A in RNA_A:RNA_G
+        @test   RNA_C in RNA_A:RNA_G
+        @test   RNA_G in RNA_A:RNA_G
+        @test !(RNA_U in RNA_A:RNA_G)
+        @test collect(RNA_C:RNA_U) == [RNA_C, RNA_G, RNA_U]
+    end
+
     @testset "Show DNA" begin
         buf = IOBuffer()
         for nt in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N]
@@ -458,6 +472,17 @@ end
         @test AA_A in alphabet(AminoAcid)
         @test AA_I in alphabet(AminoAcid)
         @test AA_U in alphabet(AminoAcid)
+    end
+
+    @testset "Range" begin
+        @test !(AA_C in AA_Q:AA_H)
+        @test   AA_Q in AA_Q:AA_H
+        @test   AA_E in AA_Q:AA_H
+        @test   AA_G in AA_Q:AA_H
+        @test   AA_H in AA_Q:AA_H
+        @test !(AA_I in AA_Q:AA_H)
+
+        @test collect(AA_W:AA_V) == [AA_W, AA_Y, AA_V]
     end
 
     @testset "Encoder" begin

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -388,8 +388,10 @@ end
         @testset "DNA" begin
             @test DNA_A + 1 == DNA_C
             @test DNA_A + 2 == DNA_G
+            @test DNA_A + 16 == DNA_A
             @test DNA_T - 1 == DNA_G
             @test DNA_T - 2 == DNA_C
+            @test DNA_T - 16 == DNA_T
             @test DNA_T - DNA_A == 3
             @test DNA_T - DNA_C == 2
             @test DNA_A < DNA_C < DNA_G < DNA_T < DNA_M < DNA_N < DNA_Gap
@@ -406,8 +408,10 @@ end
         @testset "RNA" begin
             @test RNA_A + 1 == RNA_C
             @test RNA_A + 2 == RNA_G
+            @test RNA_A + 16 == RNA_A
             @test RNA_U - 1 == RNA_G
             @test RNA_U - 2 == RNA_C
+            @test RNA_U - 16 == RNA_U
             @test RNA_U - RNA_A == 3
             @test RNA_U - RNA_C == 2
             @test RNA_A < RNA_C < RNA_G < RNA_U < RNA_M < RNA_N < RNA_Gap
@@ -459,8 +463,10 @@ end
         @test AA_A + 1 == AA_R
         @test AA_R + 1 == AA_N
         @test AA_A + 2 == AA_N
+        @test AA_A + 28 == AA_A
         @test AA_R - 1 == AA_A
         @test AA_N - 2 == AA_A
+        @test AA_A - 28 == AA_A
         @test AA_D - AA_A ==  3
         @test AA_A - AA_D == -3
         @test (AA_A < AA_R < AA_N < AA_V < AA_O < AA_U <

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -442,19 +442,41 @@ end
     end
 
     @testset "Show DNA" begin
-        buf = IOBuffer()
-        for nt in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N]
-            show(buf, nt)
+        @testset "print" begin
+            buf = IOBuffer()
+            for nt in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N, DNA_Gap]
+                print(buf, nt)
+            end
+            @test takebuf_string(buf) == "ACGTN-"
         end
-        @test takebuf_string(buf) == "ACGTN"
+
+        @testset "show" begin
+            buf = IOBuffer()
+            for nt in [DNA_A, DNA_C, DNA_G, DNA_T, DNA_N, DNA_Gap]
+                show(buf, nt)
+                write(buf, ' ')
+            end
+            @test takebuf_string(buf) == "DNA_A DNA_C DNA_G DNA_T DNA_N DNA_Gap "
+        end
     end
 
     @testset "Show RNA" begin
-        buf = IOBuffer()
-        for nt in [RNA_A, RNA_C, RNA_G, RNA_U, RNA_N]
-            show(buf, nt)
+        @testset "print" begin
+            buf = IOBuffer()
+            for nt in [RNA_A, RNA_C, RNA_G, RNA_U, RNA_N, RNA_Gap]
+                print(buf, nt)
+            end
+            @test takebuf_string(buf) == "ACGUN-"
         end
-        @test takebuf_string(buf) == "ACGUN"
+
+        @testset "show" begin
+            buf = IOBuffer()
+            for nt in [RNA_A, RNA_C, RNA_G, RNA_U, RNA_N, RNA_Gap]
+                show(buf, nt)
+                write(buf, ' ')
+            end
+            @test takebuf_string(buf) == "RNA_A RNA_C RNA_G RNA_U RNA_N RNA_Gap "
+        end
     end
 end
 
@@ -518,6 +540,25 @@ end
             @test iscompatible(x, AA_J) == (x ∈ (AA_I, AA_L, AA_J, AA_X))
             @test iscompatible(x, AA_Z) == (x ∈ (AA_E, AA_Q, AA_Z, AA_X))
             @test iscompatible(x, AA_X) == (x ∉ (AA_Term, AA_Gap))
+        end
+    end
+
+    @testset "Show amino acid" begin
+        @testset "print" begin
+            buf = IOBuffer()
+            for aa in [AA_A, AA_D, AA_B, AA_X, AA_Term, AA_Gap]
+                print(buf, aa)
+            end
+            @test takebuf_string(buf) == "ADBX*-"
+        end
+
+        @testset "show" begin
+            buf = IOBuffer()
+            for aa in [AA_A, AA_D, AA_B, AA_X, AA_Term, AA_Gap]
+                show(buf, aa)
+                write(buf, ' ')
+            end
+            @test takebuf_string(buf) == "AA_A AA_D AA_B AA_X AA_Term AA_Gap "
         end
     end
 


### PR DESCRIPTION
This pull request includes three topics:

1. Introduce `SymbolRange` type which is similar to `Base.UnitRange` but specialized for our biological symbols.
2. Make symbol arithmetic cyclic; for example, `DNA_A + 16` is `DNA_A`, not `DNA_INVALID`.
3. Make `show(io::IO, Nucleotide|AminoAcid)` more informative; for example `show(AA_A)` shows `AA_A` not `A`.

2 depends on 1, and 3 is a thing I want for a long time.
```
julia> seq = dna"ACGT"
4nt DNA Sequence:
ACGT

julia> seq[1]  # if we show 'A', we cannot see it from RNA and amino acid
DNA_A

```

If you need one-letter representation, you can call `print` instead of `show`.