### PR TITLE
make show(strand) more informative

### DIFF
--- a/src/intervals/strand.jl
+++ b/src/intervals/strand.jl
@@ -11,26 +11,19 @@ bitstype 8 Strand
 Base.convert(::Type{Strand}, strand::UInt8) = reinterpret(Strand, strand)
 Base.convert(::Type{UInt8}, strand::Strand) = reinterpret(UInt8, strand)
 
-const STRAND_NA   = convert(Strand, 0b000)
-const STRAND_POS  = convert(Strand, 0b001)
-const STRAND_NEG  = convert(Strand, 0b010)
-const STRAND_BOTH = convert(Strand, 0b011)
-
-function Base.show(io::IO, strand::Strand)
-    if strand == STRAND_NA
-        print(io, "?")
-    elseif strand == STRAND_POS
-        print(io, "+")
-    elseif strand == STRAND_NEG
-        print(io, "-")
-    elseif strand == STRAND_BOTH
-        print(io, ".")
-    else
-        print(io, "(undefined strand)")
-    end
-end
-
 Base.isless(a::Strand, b::Strand) = convert(UInt8, a) < convert(UInt8, b)
+
+"Unknown strand ('?')"
+const STRAND_NA   = convert(Strand, 0b000)
+
+"Positive strand ('+')"
+const STRAND_POS  = convert(Strand, 0b001)
+
+"Negative strand ('-')"
+const STRAND_NEG  = convert(Strand, 0b010)
+
+"Both strand ('.')"
+const STRAND_BOTH = convert(Strand, 0b011)
 
 function Base.convert(::Type{Strand}, strand::Char)
     if strand == '+'
@@ -42,6 +35,34 @@ function Base.convert(::Type{Strand}, strand::Char)
     elseif strand == '?'
         return STRAND_NA
     else
-        error("$(strand) is not a valid strand")
+        error("'$(strand)' is not a valid strand")
+    end
+end
+
+function Base.show(io::IO, strand::Strand)
+    if strand == STRAND_NA
+        print(io, "STRAND_NA")
+    elseif strand == STRAND_POS
+        print(io, "STRAND_POS")
+    elseif strand == STRAND_NEG
+        print(io, "STRAND_NEG")
+    elseif strand == STRAND_BOTH
+        print(io, "STRAND_BOTH")
+    else
+        print(io, "(undefined strand)")
+    end
+end
+
+function Base.print(io::IO, strand::Strand)
+    if strand == STRAND_NA
+        print(io, "?")
+    elseif strand == STRAND_POS
+        print(io, "+")
+    elseif strand == STRAND_NEG
+        print(io, "-")
+    elseif strand == STRAND_BOTH
+        print(io, ".")
+    else
+        error("try to print an invalid strand")
     end
 end

--- a/test/intervals/runtests.jl
+++ b/test/intervals/runtests.jl
@@ -122,6 +122,38 @@ function simple_coverage(intervals)
     return covintervals
 end
 
+@testset "Strand" begin
+    @testset "Constructor" begin
+        @test Strand('?') === STRAND_NA
+        @test Strand('+') === STRAND_POS
+        @test Strand('-') === STRAND_NEG
+        @test Strand('.') === STRAND_BOTH
+        @test_throws Exception Strand('x')
+    end
+
+    @testset "Order" begin
+        @test STRAND_NA < STRAND_POS < STRAND_NEG < STRAND_BOTH
+    end
+
+    @testset "Show" begin
+        @testset "show" begin
+            buf = IOBuffer()
+            for s in [STRAND_NA, STRAND_POS, STRAND_NEG, STRAND_BOTH]
+                show(buf, s); print(buf, " ")
+            end
+            @test takebuf_string(buf) == "STRAND_NA STRAND_POS STRAND_NEG STRAND_BOTH "
+        end
+
+        @testset "print" begin
+            buf = IOBuffer()
+            for s in [STRAND_NA, STRAND_POS, STRAND_NEG, STRAND_BOTH]
+                print(buf, s)
+            end
+            @test takebuf_string(buf) == "?+-."
+        end
+    end
+end
+
 @testset "Interval" begin
     @testset "Constructor" begin
         i = Interval("chr1", 10, 20)


### PR DESCRIPTION
Like #190, this pull request makes `show(::Strand)` more informative when used in REPL and so on. Docstrings and tests are also added.