### PR TITLE
fix FASTA writer interfaces

### DIFF
--- a/docs/src/man/reading.md
+++ b/docs/src/man/reading.md
@@ -57,3 +57,25 @@ making it easy to allocate an empty entry for any parser stream.
 entry = eltype(stream)()
 ```
 
+
+## Writing data
+
+Writing data into a stream has a uniform interface consistent with parsers. The
+following code is a template of formatted serialization into a file:
+```julia
+# open a file of a particular file format in writing mode
+out = open(<filepath>, "w", <format>)
+# write a record into it
+write(out, <record>)
+# finally close it
+close(out)
+```
+
+For example, a FASTA file will be created as follows:
+```julia
+out = open("out.fasta", "w", FASTA)
+write(out, FASTASeqRecord("seq1", dna"ACGTN"))
+write(out, FASTASeqRecord("seq2", dna"TTATATTATTGTAAA", "AT rich"))
+# and more records
+close(out)
+```

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -114,7 +114,6 @@ export
     AA_Term,
     AA_Gap,
     FASTA,
-    FASTAMetadata,
     FASTASeqRecord,
     FASTQ,
     Alphabet,
@@ -128,8 +127,7 @@ export
     approxsearchindex,
     approxrsearch,
     approxrsearchindex,
-    ReferenceSequence,
-    SeqRecord
+    ReferenceSequence
 
 using
     BufferedStreams,
@@ -195,4 +193,4 @@ include("search/approx.jl")
 
 include("deprecated.jl")
 
-end # module Seq
+end  # module Bio.Seq

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -2138,7 +2138,18 @@ end
 
 @testset "Parsing" begin
     @testset "FASTA" begin
-        get_bio_fmt_specimens()
+        output = IOBuffer()
+        writer = Seq.FASTAWriter(output, 5)
+        write(writer, FASTASeqRecord("seq1", dna"TTA"))
+        write(writer, FASTASeqRecord("seq2", dna"ACGTNN", "some description"))
+        flush(writer)
+        @test takebuf_string(output) == """
+        >seq1
+        TTA
+        >seq2 some description
+        ACGTN
+        N
+        """
 
         function check_fasta_parse(filename)
             # Reading from a stream
@@ -2174,6 +2185,7 @@ end
             return expected_entries == read_entries
         end
 
+        get_bio_fmt_specimens()
         path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "FASTA")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             tags = specimen["tags"]


### PR DESCRIPTION
This restores the `FASTASeqRecord` type alias, which I removed without careful thought.

I think `FASTAMetadata` will not be used by users because `FASTASeqRecord` is able to create a FASTA record for serialization. So, I removed it from the exported list (#207).

I will fix interfaces for other formats very soon.