### PR TITLE
fix FASTQ writer interfaces

### DIFF
--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -116,6 +116,7 @@ export
     FASTA,
     FASTASeqRecord,
     FASTQ,
+    FASTQSeqRecord,
     Alphabet,
     DNAAlphabet,
     RNAAlphabet,


### PR DESCRIPTION
As per `FASTASeqRecord`, this makes it easier to create FASTQ sequence records that can be serialized using `FASTQWriter`.