### PR TITLE
add BEDWriter

### DIFF
--- a/src/intervals/Intervals.jl
+++ b/src/intervals/Intervals.jl
@@ -39,7 +39,10 @@ using
     Bio.Ragel,
     Bio.StringFields
 
-import Bio.IO: FileFormat, AbstractParser
+import Bio.IO:
+    FileFormat,
+    AbstractParser,
+    AbstractWriter
 
 using Base.Collections:
     heappush!,

--- a/test/intervals/runtests.jl
+++ b/test/intervals/runtests.jl
@@ -421,11 +421,13 @@ end
 
             # Check round trip
             output = IOBuffer()
+            writer = Intervals.BEDWriter(output, -1)
             expected_entries = Any[]
             for interval in open(filename, BED)
-                write(output, interval)
+                write(writer, interval)
                 push!(expected_entries, interval)
             end
+            flush(writer)
 
             read_entries = Any[]
             for interval in open(takebuf_array(output), BED)


### PR DESCRIPTION
Like FASTAWriter and FASTQWriter, this adds BEDWriter and its interfaces for serializing intervals in BED format.