### PR TITLE
Added nightly builds as an allowed failiure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ os:
   - osx
 julia:
   - 0.4
+  - nightly
+matrix:
+  allow_failures:
+    - julia: nightly  
 notifications:
   email: false
 # sudo: false


### PR DESCRIPTION
Allow nightly builds but let them fail without affecting our build status. So we can see how Bio.jl does on the cutting edge of julia.