### PR TITLE
Added sidecar to docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -28,6 +28,8 @@ extra_css:
 extra_javascript:
   - https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML
   - assets/mathjaxhelper.js
+  - https://sidecar.gitter.im/dist/sidecar.v1.js
+  - assets/sidecar.js
 
 # Extensions
 markdown_extensions:

--- a/docs/src/assets/sidecar.js
+++ b/docs/src/assets/sidecar.js
@@ -1,0 +1,3 @@
+((window.gitter = {}).chat = {}).options = {
+    room: 'BioJulia/Bio.jl'
+};


### PR DESCRIPTION
Thought it would be cool for readers of docs if it was possible to have Gitter sidecar in there, so if they see something and have questions, they can immediately pop it open and talk to someone.

I believe I've done this correctly with mkdocs, _but_ I'm not 100% sure, and we can't see how it affects the page until we merge to master.