### PR TITLE
Refactored the branchlength setting and getting API.

### DIFF
--- a/docs/src/man/phylo.md
+++ b/docs/src/man/phylo.md
@@ -1,0 +1,55 @@
+# Bio.Phylo: Phylogenetic trees and networks
+
+```@meta
+CurrentModule = Bio.Phylo
+DocTestSetup = quote
+    using Bio.Phylo
+end
+```
+
+The `Bio.Phylo` module is for data types and methods for handling phylogenetic
+trees and networks.
+
+## Phylogenies
+
+```@doc
+Phylogeny
+```
+
+### Constructors
+
+You can create a very simple unresolved phylogeny (a star phylogeny) by
+providing the tips as a vector of strings or a vector of symbols.
+
+```@example
+tips = [:A, :B, :C]
+tree = Phylogeny(tips)
+```
+
+```@example starstring
+tips = ["A", "B", "C"]
+tree = Phylogeny(tips)
+```
+
+### Roots
+
+You can test whether a phylogeny is rooted, is re-rootable, and get the root
+vertex of a phylogeny. You can also test if a vertex of a phylogeny is a root.
+
+```@doc
+isrooted
+isrerootable
+root
+``
+
+```@example
+isrooted(tree)
+```
+
+```@example
+isrerootable(tree)
+```
+
+```@example
+root(tree)
+```

--- a/src/phylo/Phylo.jl
+++ b/src/phylo/Phylo.jl
@@ -53,11 +53,11 @@ export
     ## Branches
     branchlength,
     branchlength!,
+    child_branches,
+    create_branch!,
+    destroy_branch!,
     empty_branch_data,
     parent_branch,
-    child_branches,
-    rem_branch!,
-    add_branch!,
 
     ## Misc
     n_possible_rooted,

--- a/src/phylo/Phylo.jl
+++ b/src/phylo/Phylo.jl
@@ -64,10 +64,10 @@ export
     n_possible_unrooted
 
 
-
 include("phylogeny.jl")
 include("node_basics.jl")
 include("branch_basics.jl")
+include("metadata.jl")
 include("manipulation.jl")
 include("dating.jl")
 

--- a/src/phylo/Phylo.jl
+++ b/src/phylo/Phylo.jl
@@ -53,6 +53,7 @@ export
     ## Branches
     branchlength,
     branchlength!,
+    empty_branch_data,
     parent_branch,
     child_branches,
     rem_branch!,

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -10,14 +10,32 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-function branchlength{C}(tree::Phylogeny{C, Float64}, edge::Edge)
-    return get(tree.edgedata, edge, -1.0)
+
+# The basic function on which getting a branch length depends,
+# For any kind of phylogeny.
+function branchlength(tree::Phylogeny, edge::Edge)
+    return branchlength(tree.edgedata[edge])
 end
 
-function branchlength!{C}(tree::Phylogeny{C, Float64}, edge::Edge, value::Float64)
-    tree.edgedata[edge] = value
-    return tree
+# The basic function on which setting a branch length depends,
+# for any kind of phylogeny. The assumption is metadata values on branches are
+# immutables or value types - hence the reassignment.
+function branchlength!(tree::Phylogeny, edge, value::Float64)
+    tree.edgedata[edge] = branchlength!(tree.edgedata[edge], value)
 end
+
+
+# An example of defining branchlength and branchlength! for a piece of metadata.
+# In this case the metadata type is a single Float64, so branches are annotated
+# with a branch length and nothing else.
+function branchlength(metadata::Float64)
+    return metadata
+end
+
+function branchlength!(metadata::Float64, value::Float64)
+    return value
+end
+
 
 function rem_branch!(tree::Phylogeny, branch::Edge)
     rem_edge!(tree.graph, src(branch), dst(branch))
@@ -25,9 +43,9 @@ function rem_branch!(tree::Phylogeny, branch::Edge)
     return tree
 end
 
-function add_branch!(tree::Phylogeny, branch::Edge, branchlength::Float64)
+function add_branch!{C,B}(tree::Phylogeny{C,B}, branch::Edge, branchdata::B)
     add_edge!(tree.graph, branch)
-    branchlength!(tree, branch, branchlength)
+    tree.edgedata[branch] = branchdata
     return tree
 end
 

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -90,10 +90,10 @@ The assumption is metadata values on branches are immutables or value types,
 hence the reassignment using the branchdata! method.
 """
 @generated function branchlength!{C,B}(tree::Phylogeny{C,B}, edge::Edge, value::Nullable{Float64})
-    if isimmutable(B)
+    if !B.mutable
         setting = :(branchdata!(tree, edge, new_branchlength(branchdata(tree, edge), value)))
     else
-        setting = :(branchlength!(branchdata(tree, edge)))
+        setting = :(branchlength!(branchdata(tree, edge), value))
     end
 
     quote

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -7,10 +7,6 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-immutable BLWrapper{T<:AbstractFloat}
-    x::Nullable{T}
-end
-
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)
 
@@ -86,16 +82,22 @@ function branchlength(tree::Phylogeny, edge::Edge)
 end
 
 """
-    branchlength!{C,B,T<:AbstractFloat}(tree::Phylogeny{C,B}, edge::Edge, value::T)
+    branchlength!{C,B}(tree::Phylogeny{C,B}, edge::Edge, value::Nullable{Float64})
 
 Set the branchlength of branch defined by `edge` in a phylogeny.
 
 The assumption is metadata values on branches are immutables or value types,
 hence the reassignment using the branchdata! method.
 """
-function branchlength!{C,B,T<:AbstractFloat}(tree::Phylogeny{C,B},
-                                             edge::Edge,
-                                             value::Nullable{T})
-    branchdata!(tree, edge, new_branchlength(branchdata(tree, edge), value))
-    return tree
+@generated function branchlength!{C,B}(tree::Phylogeny{C,B}, edge::Edge, value::Nullable{Float64})
+    if isimmutable(B)
+        setting = :(branchdata!(tree, edge, new_branchlength(branchdata(tree, edge), value)))
+    else
+        setting = :(branchlength!(branchdata(tree, edge)))
+    end
+
+    quote
+        $setting
+        return tree
+    end
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -10,12 +10,10 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-typealias BranchFields Union{Symbol, AbstractString, Integer}
 
-immutable Branch{T <: BranchFields}
-    from::T
-    to::T
-end
+# Any type used as branch metadata should have the following methods defined.
+
+# branchlength, branchlength!
 
 
 """
@@ -35,7 +33,6 @@ end
 
 Getter for metadata associated with branch represented by `edge`.
 """
-# Functions responsible for getting and setting branch data.
 function branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)
     return get(tree.edgedata, edge, empty_branch_data(B))
 end
@@ -49,7 +46,7 @@ function branchdata!{C,B}(tree::Phylogeny{C,B}, edge::Edge, data::B)
     if has_edge(tree.graph, edge)
         tree.edgedata[edge] = data
     else
-        warn("You tried to set branch data to a non-existant branch. Consequently, nothing was done.")
+        warn("You tried to assign branch data to a non-existant branch. Consequently, nothing was done.")
     end
     return tree
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -1,40 +1,18 @@
 # phylo/branch_basics.jl
 # ======================
 #
-# Types and methods for phylogenetic trees.
+# Types and methods for manipulating the branches of phylogenies and networks.
 #
 # Part of the Bio.Phylo module.
-#
-# This file contains methods for querying and setting attributes on branches,
-# as well as adding and removing branches.
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 
-# Any type used as branch metadata should have the following methods defined.
-
-# An empty constructor.
-# A constructor that takes a BranchLength type as a
-
-abstract BranchMetaData
-
-immutable BasicBranch <: BranchMetaData
-    len::Nullable{Float64}
-    conf::Nullable{Float64}
+# Lightweight immutable type required to wrap values and distinguish
+# them from other values for the purposes of dispatch.
+immutable BranchLength{T}
+    val::T
 end
-
-@inline function BasicBranch()
-    return BasicBranch(Nullable{Float64}(), Nullable{Float64}())
-end
-
-@inline function BasicBranch{T}(x::BasicBranch, len::BranchLength{T})
-    return BasicBranch(convert(Nullable{Float64}, len), x.conf)
-end
-
-function branchlength(x::BasicBranch)
-    return x.len
-end
-
 
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)
@@ -99,15 +77,6 @@ end
 
 function child_branches(tree::Phylogeny, vertex::Int)
     return out_edges(tree.graph, vertex)
-end
-
-
-# Get and set branchlength mechanism for phylogeneies.
-
-# Lightweight immutable type required to wrap values and distinguish
-# them from other values for the purposes of dispatch.
-immutable BranchLength{T}
-    val::T
 end
 
 """

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -101,3 +101,8 @@ hence the reassignment using the branchdata! method.
         return tree
     end
 end
+
+function branchlength!(tree::Phylogeny, edge::Edge, value::Float64)
+    bl = ifelse(value <= 0.0, Nullable(value), Nullable{Float64}())
+    return branchlength!(tree, edge, bl)
+end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -103,6 +103,6 @@ hence the reassignment using the branchdata! method.
 end
 
 function branchlength!(tree::Phylogeny, edge::Edge, value::Float64)
-    bl = ifelse(value <= 0.0, Nullable(value), Nullable{Float64}())
+    bl = ifelse(value <= 0.0, Nullable{Float64}(), Nullable(value))
     return branchlength!(tree, edge, bl)
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -13,7 +13,7 @@
 immutable BranchLength{T}
     val::T
 end
-Base.convert{T}(T, x::BranchLength{T}) = x.val
+Base.convert{T}(::Type{T}, x::BranchLength{T}) = x.val
 
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -11,8 +11,6 @@ immutable BLWrapper{T<:AbstractFloat}
     x::Nullable{T}
 end
 
-typealias BranchLength{T<:AbstractFloat} Nullable{T}
-
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)
 
@@ -98,6 +96,6 @@ hence the reassignment using the branchdata! method.
 function branchlength!{C,B,T<:AbstractFloat}(tree::Phylogeny{C,B},
                                              edge::Edge,
                                              value::Nullable{T})
-    branchdata!(tree, edge, B(branchdata(tree, edge), BLWrapper(value)))
+    branchdata!(tree, edge, new_branchlength(branchdata(tree, edge), value))
     return tree
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -7,13 +7,7 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-
-# Lightweight immutable type required to wrap values and distinguish
-# them from other values for the purposes of dispatch.
-immutable BranchLength{T}
-    val::T
-end
-Base.convert{T}(::Type{T}, x::BranchLength{T}) = x.val
+typealias BranchLength{T<:AbstractFloat} Nullable{T}
 
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)
@@ -97,7 +91,7 @@ Set the branchlength of branch defined by `edge` in a phylogeny.
 The assumption is metadata values on branches are immutables or value types,
 hence the reassignment using the branchdata! method.
 """
-function branchlength!{C,B,T}(tree::Phylogeny{C,B}, edge::Edge, value::T)
-    branchdata!(tree, edge, B(branchdata(tree, edge), BranchLength(value)))
+function branchlength!{C,B,T}(tree::Phylogeny{C,B}, edge::Edge, value::BranchLength)
+    branchdata!(tree, edge, B(branchdata(tree, edge), value))
     return tree
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -7,6 +7,10 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
+immutable BLWrapper{T<:AbstractFloat}
+    x::Nullable{T}
+end
+
 typealias BranchLength{T<:AbstractFloat} Nullable{T}
 
 """
@@ -91,7 +95,9 @@ Set the branchlength of branch defined by `edge` in a phylogeny.
 The assumption is metadata values on branches are immutables or value types,
 hence the reassignment using the branchdata! method.
 """
-function branchlength!{C,B,T}(tree::Phylogeny{C,B}, edge::Edge, value::BranchLength)
-    branchdata!(tree, edge, B(branchdata(tree, edge), value))
+function branchlength!{C,B,T<:AbstractFloat}(tree::Phylogeny{C,B},
+                                             edge::Edge,
+                                             value::Nullable{T})
+    branchdata!(tree, edge, B(branchdata(tree, edge), BLWrapper(value)))
     return tree
 end

--- a/src/phylo/branch_basics.jl
+++ b/src/phylo/branch_basics.jl
@@ -13,6 +13,7 @@
 immutable BranchLength{T}
     val::T
 end
+Base.convert{T}(T, x::BranchLength{T}) = x.val
 
 """
     branchdata{C,B}(tree::Phylogeny{C,B}, edge::Edge)

--- a/src/phylo/manipulation.jl
+++ b/src/phylo/manipulation.jl
@@ -52,7 +52,7 @@ Unconnects the root vertex from all of its children.
 function disconnect_root!(tree::Phylogeny)
     r = root(tree)
     for i in children(tree, r)
-        rem_branch!(tree, Edge(r, i))
+        destroy_branch!(tree, Edge(r, i))
     end
     return tree
 end
@@ -68,11 +68,11 @@ function Base.delete!(tree::Phylogeny, vertex::Int, preserve_bl::Bool = false)
     # deleted branch.
     parentedge = Edge(p, vertex)
     lentoparent = preserve_bl ? branchlength(tree, parentedge) : 0.0
-    rem_branch!(tree, parentedge)
+    destroy_branch!(tree, parentedge)
     for branch in child_branches(tree, vertex)
         newbl = branchlength(tree, branch) + lentoparent
         add_branch!(tree, Edge(parent, dst(branch)), newbl)
-        rem_branch!(tree, Edge(vertex, dst(branch)))
+        destroy_branch!(tree, Edge(vertex, dst(branch)))
     end
     return tree
 end

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -14,17 +14,17 @@
 
 abstract BranchMetaData
 
-immutable BasicBranch <: BranchMetaData
-    len::Nullable{Float64}
-    conf::Nullable{Float64}
+immutable BasicBranch{T<:AbstractFloat} <: BranchMetaData
+    len::Nullable{T}
+    conf::Nullable{T}
 end
 
-@inline function BasicBranch()
-    return BasicBranch(Nullable{Float64}(), Nullable{Float64}())
+@inline function BasicBranch{T<:AbstractFloat}()
+    return BasicBranch(Nullable{T}(), Nullable{T}())
 end
 
-@inline function BasicBranch{T}(x::BasicBranch, len::BranchLength{T})
-    return BasicBranch(convert(Nullable{Float64}, len), x.conf)
+@inline function BasicBranch{T<:AbstractFloat}(x::BasicBranch{T}, len::BranchLength)
+    return BasicBranch{B}(convert(Nullable{T}, len), x.conf)
 end
 
 function branchlength(x::BasicBranch)

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -1,0 +1,32 @@
+# phylo/metadata.jl
+# =================
+#
+# Types and methods for metadata attached to phylogenies.
+#
+# Part of the Bio.Phylo module.
+#
+# This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+# Any type used as branch metadata should have the following methods defined.
+
+# An empty constructor.
+# A constructor that takes a BranchLength type as a second argument.
+
+abstract BranchMetaData
+
+immutable BasicBranch <: BranchMetaData
+    len::Nullable{Float64}
+    conf::Nullable{Float64}
+end
+
+@inline function BasicBranch()
+    return BasicBranch(Nullable{Float64}(), Nullable{Float64}())
+end
+
+@inline function BasicBranch{T}(x::BasicBranch, len::BranchLength{T})
+    return BasicBranch(convert(Nullable{Float64}, len), x.conf)
+end
+
+function branchlength(x::BasicBranch)
+    return x.len
+end

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -23,8 +23,8 @@ end
     return BasicBranch(Nullable{T}(), Nullable{T}())
 end
 
-@inline function BasicBranch{T<:AbstractFloat}(x::BasicBranch{T}, len::BranchLength)
-    return BasicBranch{B}(convert(Nullable{T}, len), x.conf)
+@inline function BasicBranch{T<:AbstractFloat}(x::BasicBranch{T}, len::BLWrapper)
+    return BasicBranch{B}(convert(Nullable{T}, len.x), x.conf)
 end
 
 function branchlength(x::BasicBranch)

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -15,19 +15,20 @@ abstract BranchMetaData
 # A no-arg constructor. e.g. BasicBranch()
 # A method called new_branchlength, which constructs a new metadata variable,
 # from the old metadata variable, and a new branchlength. The new branchlength
-# should be of type Nullable.
+# should be of type Nullable{Float64}.
+# A method branchlength which returns the branchlength
 
-immutable BasicBranch{T<:AbstractFloat} <: BranchMetaData
-    len::Nullable{T}
-    conf::Nullable{T}
+immutable BasicBranch <: BranchMetaData
+    len::Nullable{Float64}
+    conf::Nullable{Float64}
 end
 
-@inline function BasicBranch{T<:AbstractFloat}()
-    return BasicBranch(Nullable{T}(), Nullable{T}())
+@inline function BasicBranch()
+    return BasicBranch(Nullable{Float64}(), Nullable{Float64}())
 end
 
-@inline function new_branchlength{T<:AbstractFloat,N<:AbstractFloat}(x::BasicBranch{T}, len::Nullable{N})
-    return BasicBranch(convert(Nullable{T}, len), x.conf)
+@inline function new_branchlength(x::BasicBranch, len::Nullable{Float64})
+    return BasicBranch(len, x.conf)
 end
 
 branchlength(x::BasicBranch) = x.len

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -7,12 +7,15 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-# Any type used as branch metadata should have the following methods defined.
-
-# An empty constructor.
-# A constructor that takes a BranchLength type as a second argument.
-
 abstract BranchMetaData
+
+# Every Metadata type should be immutable, and should have the following
+# methods defined:
+#
+# A no-arg constructor. e.g. BasicBranch()
+# A method called new_branchlength, which constructs a new metadata variable,
+# from the old metadata variable, and a new branchlength. The new branchlength
+# should be of type Nullable.
 
 immutable BasicBranch{T<:AbstractFloat} <: BranchMetaData
     len::Nullable{T}
@@ -23,10 +26,8 @@ end
     return BasicBranch(Nullable{T}(), Nullable{T}())
 end
 
-@inline function BasicBranch{T<:AbstractFloat}(x::BasicBranch{T}, len::BLWrapper)
-    return BasicBranch{B}(convert(Nullable{T}, len.x), x.conf)
+@inline function new_branchlength{T<:AbstractFloat,N<:AbstractFloat}(x::BasicBranch{T}, len::Nullable{N})
+    return BasicBranch(convert(Nullable{T}, len), x.conf)
 end
 
-function branchlength(x::BasicBranch)
-    return x.len
-end
+branchlength(x::BasicBranch) = x.len

--- a/src/phylo/phylogeny.jl
+++ b/src/phylo/phylogeny.jl
@@ -60,7 +60,7 @@ Phylogeny(Void, Void, [:Human, :Chimp, :Dog, :Cat])
 Phylogeny(Float64, Float64, [:Human, :Chimp, :Dog, :Cat])
 ```
 """
-function Phylogeny{C, B}(::Type{C}, ::Type{B}, taxa::Vector{Symbol})
+function Phylogeny{C,B}(::Type{C}, ::Type{B}, taxa::Vector{Symbol})
     ntaxa = length(taxa)
     maxVertices = maxvertices(ntaxa)
     taxaAndRoot = push!(copy(taxa), :Root)
@@ -70,8 +70,8 @@ function Phylogeny{C, B}(::Type{C}, ::Type{B}, taxa::Vector{Symbol})
         add_edge!(g, ntaxa + 1, i)
     end
     v = Vector{C}()
-    d = Dict{Edge, B}()
-    return Phylogeny{C, B}(g, idxer, v, d, ntaxa, false, true)
+    d = Dict{Edge,B}()
+    return Phylogeny{C,B}(g, idxer, v, d, ntaxa, false, true)
 end
 
 """

--- a/src/phylo/phylogeny.jl
+++ b/src/phylo/phylogeny.jl
@@ -89,7 +89,7 @@ Phylogeny([:Human, :Chimp, :Dog, :Cat])
 ```
 """
 function Phylogeny(taxa::Vector{Symbol})
-    return Phylogeny(Float64, Float64, taxa)
+    return Phylogeny(Float64, BasicBranch, taxa)
 end
 
 """

--- a/src/util/indexing.jl
+++ b/src/util/indexing.jl
@@ -170,7 +170,7 @@ end
 """
     make_unique(names::Vector{Symbol})
 
-Make sure all vectors in a symbol are unique.
+Make sure all symbols in a vector are unique.
 
 # Examples
 ```julia

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -123,7 +123,8 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
             @test child_branches(destroy_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]
-            @test child_branches(create_branch!(tree, Edge(4, 1), 0.5), 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
+            @test child_branches(create_branch!(tree, Edge(4, 1),
+                    Phylo.BasicBranch(Nullable(0.237), Nullable{Float64}())), 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
         end
 
         @testset "Manipulation" begin

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -118,7 +118,7 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
         end
 
         @testset "Branches" begin
-            @test branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1)) == Nullable(0.237)
+            @test get(branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1))) == get(Nullable(0.237))
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
             @test child_branches(destroy_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -118,6 +118,7 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
         end
 
         @testset "Branches" begin
+        branchlength!(tree, Edge(4, 1), 0.237)
             @test get(branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1))) == get(Nullable(0.237))
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -121,7 +121,7 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
             @test branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1)) == 0.237
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
-            @test child_branches(rem_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]
+            @test child_branches(destroy_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]
             @test child_branches(add_branch!(tree, Edge(4, 1), 0.5), 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
         end
 

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -122,7 +122,7 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
             @test child_branches(destroy_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]
-            @test child_branches(add_branch!(tree, Edge(4, 1), 0.5), 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
+            @test child_branches(create_branch!(tree, Edge(4, 1), 0.5), 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
         end
 
         @testset "Manipulation" begin

--- a/test/phylo/runtests.jl
+++ b/test/phylo/runtests.jl
@@ -118,7 +118,7 @@ using Bio.Var: AnyMutation, TransitionMutation, TransversionMutation
         end
 
         @testset "Branches" begin
-            @test branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1)) == 0.237
+            @test branchlength(branchlength!(tree, Edge(4, 1), 0.237), Edge(4, 1)) == Nullable(0.237)
             @test parent_branch(tree, 1) == Edge(4, 1)
             @test child_branches(tree, 4) == [Edge(4, 1), Edge(4, 2), Edge(4, 3)]
             @test child_branches(destroy_branch!(tree, Edge(4, 1)), 4) == [Edge(4, 2), Edge(4, 3)]


### PR DESCRIPTION
This is a very simple change to Phylo. It alters the branchlength and branchlength! methods so as when people create immutable types to act as branch metadata, if they just define a branchlength and branchlength! method for that type, then getting and setting the branch length for any phylogeny type should "just work". 
