### PR TITLE
Export isambiguous from Seq module.

### DIFF
--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -241,6 +241,7 @@ false
 alphabet
 gap
 iscompatible
+isambiguous
 ```
 
 

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -45,6 +45,7 @@ export
     RNA_N,
     RNA_Gap,
     iscompatible,
+    isambiguous,
     Sequence,
     BioSequence,
     DNASequence,

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -306,6 +306,15 @@ end
         end
     end
 
+    @testset "isambiguous" begin
+        for x in alphabet(DNANucleotide)
+            @test isambiguous(x) == (x > DNA_T)
+        end
+        for x in alphabet(RNANucleotide)
+            @test isambiguous(x) == (x > RNA_U)
+        end
+    end
+
     @testset "complement" begin
         @test Seq.complement(DNA_A) == DNA_T
         @test Seq.complement(DNA_C) == DNA_G
@@ -554,6 +563,12 @@ end
             @test iscompatible(x, AA_J) == (x ∈ (AA_I, AA_L, AA_J, AA_X))
             @test iscompatible(x, AA_Z) == (x ∈ (AA_E, AA_Q, AA_Z, AA_X))
             @test iscompatible(x, AA_X) == (x ∉ (AA_Term, AA_Gap))
+        end
+    end
+
+    @testset "isambiguous" begin
+        for x in alphabet(AminoAcid)
+            @test isambiguous(x) == (AA_B <= x <= AA_X)
         end
     end
 


### PR DESCRIPTION
Very simple PR.

Sometimes if a user is dealing with individual nucleotides, or iterating a seq nucleotide by nucleotide, it would be useful to be able to use the isambiguous method.