### PR TITLE
Fix fastq quality encoding inference

### DIFF
--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -6,11 +6,11 @@
 
 if VERSION < v"0.5-"
     precompile(Base.open, (ASCIIString, Type{Seq.FASTA},))
-    precompile(Base.open, (ASCIIString, Type{Seq.FASTQ},))
+    precompile(Base.open, (ASCIIString, Type{Seq.FASTQ}, Type{Seq.QualityEncoding},))
     precompile(Base.open, (ASCIIString, Type{Intervals.BED},))
 else
     precompile(Base.open, (String, Type{Seq.FASTA},))
-    precompile(Base.open, (String, Type{Seq.FASTQ},))
+    precompile(Base.open, (String, Type{Seq.FASTQ}, Type{Seq.QualityEncoding},))
     precompile(Base.open, (String, Type{Intervals.BED},))
 end
 precompile(Base.read, (Seq.FASTAParser{Seq.BioSequence},))

--- a/src/seq/fastq.jl
+++ b/src/seq/fastq.jl
@@ -59,7 +59,7 @@ function Base.open(
         ascii_offset::Integer=typemin(Int))
     io = open(filepath, mode)
     if mode[1] == 'r'
-        return open(BufferedInputStream(io), FASTQ; quality_encoding=quality_encoding)
+        return open(BufferedInputStream(io), FASTQ, quality_encoding)
     elseif mode[1] ∈ ('w', 'a')
         return FASTQWriter(io, quality_header, ascii_offset)
     end
@@ -67,8 +67,8 @@ function Base.open(
 end
 
 function Base.open{S}(input::BufferedInputStream, ::Type{FASTQ},
+                      quality_encoding::QualityEncoding,
                       ::Type{S}=DNASequence;
-                      quality_encoding::QualityEncoding=EMPTY_QUAL_ENCODING,
                       # TODO: remove this option after v0.2
                       qualenc=quality_encoding)
     return FASTQParser{S}(input, quality_encoding)

--- a/src/seq/fastq.jl
+++ b/src/seq/fastq.jl
@@ -90,6 +90,13 @@ type FASTQParser{S<:Sequence} <: AbstractParser
 
     function FASTQParser(input::BufferedInputStream,
                          quality_encodings::QualityEncoding)
+        if quality_encodings == EMPTY_QUAL_ENCODING
+            error("The `quality_encodings` argument is required when parsing FASTQ.")
+        elseif count_ones(convert(UInt16, quality_encodings)) > 1
+            error("The `quality_encodings` argument must specify exactly one encoding.")
+        elseif count_ones(convert(UInt16, quality_encodings & ALL_QUAL_ENCODINGS)) != 1
+            error("Unknown quality encoding.")
+        end
         return new(Ragel.State(fastqparser_start, input),
                    BufferedOutputStream(), BufferedOutputStream(),
                    StringField(), StringField(), 0, quality_encodings)

--- a/src/seq/quality.jl
+++ b/src/seq/quality.jl
@@ -90,7 +90,6 @@ giving the set of compatible encodings.
 function infer_quality_encoding(data::Vector{UInt8}, start, stop,
                                 encodings::QualityEncoding=ALL_QUAL_ENCODINGS,
                                 default::QualityEncoding=EMPTY_QUAL_ENCODING)
-    encodings = ALL_QUAL_ENCODINGS
     @inbounds for i in start:stop
         c = data[i]
         if '!' <= c <= '~'

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -2764,15 +2764,15 @@ end
 
         function check_fastq_parse(filename)
             # Reading from a stream
-            for seqrec in open(filename, FASTQ)
+            for seqrec in open(filename, FASTQ, Seq.SANGER_QUAL_ENCODING)
             end
 
             # Reading from a memory mapped file
-            for seqrec in open(filename, FASTQ, memory_map=true)
+            for seqrec in open(filename, FASTQ, Seq.SANGER_QUAL_ENCODING, memory_map=true)
             end
 
             # in-place parsing
-            stream = open(filename, FASTQ)
+            stream = open(filename, FASTQ, Seq.SANGER_QUAL_ENCODING)
             entry = eltype(stream)()
             while !eof(stream)
                 read!(stream, entry)
@@ -2782,14 +2782,14 @@ end
             output = IOBuffer()
             writer = Seq.FASTQWriter(output, false, typemin(Int))
             expected_entries = Any[]
-            for seqrec in open(filename, FASTQ)
+            for seqrec in open(filename, FASTQ, Seq.SANGER_QUAL_ENCODING)
                 write(writer, seqrec)
                 push!(expected_entries, seqrec)
             end
             flush(writer)
 
             read_entries = Any[]
-            for seqrec in open(takebuf_array(output), FASTQ)
+            for seqrec in open(takebuf_array(output), FASTQ, Seq.SANGER_QUAL_ENCODING)
                 push!(read_entries, seqrec)
             end
 
@@ -2822,7 +2822,7 @@ end
             """)
             for A in (DNAAlphabet{2}, DNAAlphabet{4})
                 seekstart(input)
-                seq = first(open(input, FASTQ, BioSequence{A})).seq
+                seq = first(open(input, FASTQ, Seq.SANGER_QUAL_ENCODING, BioSequence{A})).seq
                 @test typeof(seq) == BioSequence{A}
             end
         end


### PR DESCRIPTION
Closes #242.

This branch fixes the problem by requiring that exactly one quality encoding is provided to the FASTQParser, so no inference is done to determine the quality encoding.

An alternative solution would infer the quality encoding for all sequences in the file at once, but then they could not be parsed record by record.