### PR TITLE
add random sequence generators

### DIFF
--- a/docs/src/man/seq.md
+++ b/docs/src/man/seq.md
@@ -408,6 +408,12 @@ true
 
 ```
 
+A random sequence can be obtained by the `randdnaseq`, `randrnaseq` and
+`randaaseq` functions, which generate `DNASequence`, `RNASequence` and
+`AminoAcidSequence`, respectively. Generated sequences are composed of the
+standard symbols without ambiguity and gap. For example, `randdnaseq(6)` may
+generate `dna"TCATAG"` but never generates `dna"TNANAG"` or `dna"T-ATAG"`.
+
 A translatable `RNASequence` can also be converted to an `AminoAcidSequence`
 using the [`translate`](@ref) function described below.
 

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -78,6 +78,7 @@ export
     npositions,
     hasn,
     gc_content,
+    SequenceGenerator,
     randdnaseq,
     randrnaseq,
     randaaseq,

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -78,6 +78,9 @@ export
     npositions,
     hasn,
     gc_content,
+    randdnaseq,
+    randrnaseq,
+    randaaseq,
     canonical,
     neighbors,
     eachkmer,
@@ -182,6 +185,7 @@ include("alphabet.jl")
 include("bitindex.jl")
 include("bioseq.jl")
 include("hash.jl")
+include("randseq.jl")
 include("kmer.jl")
 include("nmask.jl")
 include("refseq.jl")

--- a/src/seq/randseq.jl
+++ b/src/seq/randseq.jl
@@ -52,11 +52,13 @@ function randseq{T}(generator::StationaryGenerator{T}, len::Integer)
 end
 
 const StationaryDNAGenerator = StationaryGenerator(
-    [DNA_A, DNA_C, DNA_G, DNA_T], [0.25, 0.25, 0.25])
+    collect(dna"ACGT"), ones(3) / 4)
+
 const StationaryRNAGenerator = StationaryGenerator(
-    [RNA_A, RNA_C, RNA_G, RNA_U], [0.25, 0.25, 0.25])
+    collect(rna"ACGU"), ones(3) / 4)
+
 const StationaryAAGenerator = StationaryGenerator(
-    alphabet(AminoAcid)[1:20], ones(19) / 20)
+    collect(aa"ARNDCQEGHILKMFPSTWYV"), ones(19) / 20)
 
 """
     randdnaseq(len::Integer)

--- a/src/seq/randseq.jl
+++ b/src/seq/randseq.jl
@@ -6,8 +6,11 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
+# abstract sequence generator type
+abstract SequenceGenerator{T}
+
 # Sequence generator of stationary distributions.
-immutable StationaryGenerator{T}
+immutable StationaryGenerator{T} <: SequenceGenerator{T}
     elems::Vector{T}
     probs::Vector{Float64}
 

--- a/src/seq/randseq.jl
+++ b/src/seq/randseq.jl
@@ -1,0 +1,83 @@
+# Random Sequence Generator
+# =========================
+#
+# Random sequence generator.
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+# Sequence generator of stationary distributions.
+immutable StationaryGenerator{T}
+    elems::Vector{T}
+    probs::Vector{Float64}
+
+    function StationaryGenerator(elems, probs)
+        @assert sum(probs) ≤ 1
+        @assert length(elems) == length(probs) + 1
+        return new(copy(elems), copy(probs))
+    end
+end
+
+function StationaryGenerator{T,U<:AbstractFloat}(
+        elems::AbstractVector{T}, probs::AbstractVector{U})
+    return StationaryGenerator{T}(elems, probs)
+end
+
+alphatype(::Type{DNANucleotide}) = DNAAlphabet{4}
+alphatype(::Type{RNANucleotide}) = RNAAlphabet{4}
+alphatype(::Type{AminoAcid})     = AminoAcidAlphabet
+
+function randseq{T}(generator::StationaryGenerator{T}, len::Integer)
+    if len < 0
+        throw(ArgumentError("length must be non-negative"))
+    end
+    seq = BioSequence{alphatype(T)}(len)
+    probs = generator.probs
+    for i in 1:len
+        r = rand()
+        j = 1
+        cumprob = probs[j]
+        while cumprob < r && j ≤ endof(probs)
+            j += 1
+            if j ≤ endof(probs)
+                cumprob += probs[j]
+            end
+        end
+        seq[i] = generator.elems[j]
+    end
+    return seq
+end
+
+const StationaryDNAGenerator = StationaryGenerator(
+    [DNA_A, DNA_C, DNA_G, DNA_T], [0.25, 0.25, 0.25])
+const StationaryRNAGenerator = StationaryGenerator(
+    [RNA_A, RNA_C, RNA_G, RNA_U], [0.25, 0.25, 0.25])
+const StationaryAAGenerator = StationaryGenerator(
+    alphabet(AminoAcid)[1:20], ones(19) / 20)
+
+"""
+    randdnaseq(len::Integer)
+
+Generate a random DNA sequence of length `len`.
+"""
+function randdnaseq(len::Integer)
+    return randseq(StationaryDNAGenerator, len)
+end
+
+"""
+    randrnaseq(len::Integer)
+
+Generate a random RNA sequence of length `len`.
+"""
+function randrnaseq(len::Integer)
+    return randseq(StationaryRNAGenerator, len)
+end
+
+"""
+    randaaseq(len::Integer)
+
+Generate a random amino acid sequence of length `len`.
+"""
+function randaaseq(len::Integer)
+    return randseq(StationaryAAGenerator, len)
+end

--- a/src/seq/randseq.jl
+++ b/src/seq/randseq.jl
@@ -6,7 +6,9 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-# abstract sequence generator type
+"""
+Abstract sequence generator type.
+"""
 abstract SequenceGenerator{T}
 
 # Sequence generator of stationary distributions.

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,3 +1,4 @@
 Distributions
 YAML
 BaseTestNext
+StatsBase

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -10,6 +10,7 @@ end
 import Compat
 using Bio.Seq,
     BufferedStreams,
+    StatsBase,
     YAML,
     TestFunctions
 
@@ -1666,6 +1667,52 @@ end
         @test ReferenceSequence(str) == DNASequence(str)
         str = ("N"^300 * random_dna(1000))^5 * "N"^300
         @test ReferenceSequence(str) == DNASequence(str)
+    end
+
+    @testset "Random sequence" begin
+        for _ in 1:10
+            @test randdnaseq(0) == dna""
+            @test randrnaseq(0) == rna""
+            @test randaaseq(0) == aa""
+        end
+
+        for _ in 1:100
+            len = rand(0:1000)
+            @test length(randdnaseq(len)) == len
+            @test length(randrnaseq(len)) == len
+            @test length(randaaseq(len)) == len
+        end
+
+        for _ in 1:100
+            len = 10_000
+
+            counts = countmap(collect(randdnaseq(len)))
+            counts_sum = 0
+            for nt in dna"ACGT"
+                # cdf(Binomial(10_000, 0.25), 2300) ≈ 1.68e-6
+                @test 2300 < counts[nt]
+                counts_sum += counts[nt]
+            end
+            @test counts_sum == len
+
+            counts = countmap(collect(randrnaseq(len)))
+            counts_sum = 0
+            for nt in rna"ACGU"
+                # cdf(Binomial(10_000, 0.25), 2300) ≈ 1.68e-6
+                @test 2300 < counts[nt]
+                counts_sum += counts[nt]
+            end
+            @test counts_sum == len
+
+            counts = countmap(collect(randaaseq(len)))
+            counts_sum = 0
+            for aa in aa"ARNDCQEGHILKMFPSTWYV"
+                # cdf(Binomial(10000, 0.05), 400) ≈ 1.21e-6
+                @test 400 < counts[aa]
+                counts_sum += counts[aa]
+            end
+            @test counts_sum == len
+        end
     end
 end
 


### PR DESCRIPTION
This adds random sequence generators for DNA, RNA, and amino acids. At the moment, the only available generator is `StationaryGenerator`, but the interface is extensible so that we can add more elaborate generators like HMM or RNN.