### PR TITLE
Add labelled square matrix parser

### DIFF
--- a/docs/src/man/labelledmatrix.md
+++ b/docs/src/man/labelledmatrix.md
@@ -1,0 +1,23 @@
+# Reference: Bio.LabelledMatrices - Labelled square matrix parsers
+
+```@meta
+CurrentModule = Bio.LabelledMatrices
+```
+
+This module contains a function `readlsm`, that reads labelled square matrices.
+
+Such matrices are commonly used to store pairwise measures of similarity or
+dissimilarity between two sets. This format consists of a delimited file,
+with text labels on the upper and left sides of a square matrix. Such matrices
+are often but not exclusively symmetric.
+
+An example would be: 
+
+```
+    A   B
+A   1   2
+B   2   1
+```
+
+(Note that we use spaces as a delimiter, where tabs would normally be used)
+

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -7,6 +7,7 @@ include("Ragel.jl")
 include("StringFields.jl")
 include("seq/Seq.jl")
 include("intervals/Intervals.jl")
+include("util/labelledmatrix.jl")  # Req'd for reading substitution matrices
 include("align/Align.jl")
 include("util/tokenize.jl")
 include("util/indexing.jl")

--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -5,9 +5,9 @@ module Bio
 include("IO.jl")
 include("Ragel.jl")
 include("StringFields.jl")
+include("util/Util.jl")
 include("seq/Seq.jl")
 include("intervals/Intervals.jl")
-include("util/labelledmatrix.jl")  # Req'd for reading substitution matrices
 include("align/Align.jl")
 include("util/tokenize.jl")
 include("util/indexing.jl")

--- a/src/util/Util.jl
+++ b/src/util/Util.jl
@@ -1,0 +1,5 @@
+module Util
+
+include("labelledmatrix.jl")
+
+end # module Util

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -2,11 +2,7 @@ export readlsm
 
 const _default_delims = [' ','\t']
 
-"""
-Reads a Labelled Square Matrix
-
-Returns a tuple of `(matrix, labels)`
-"""
+"Reads a Labelled Square Matrix, returning a tuple of `(matrix, labels)`"
 function readlsm{T}(::Type{T}, io::IO, delim=_default_delims, comment='#')
     matrix = Matrix{T}()
     labels = UTF8String[]

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -1,5 +1,3 @@
-module LabelledSquareMatrices
-
 export readlsm
 
 """
@@ -56,5 +54,3 @@ end
 function readlsm(path::AbstractString, delim='\t')
     return readlsm(Float64, path, delim)
 end
-
-end # module LabelledSquareMatrices

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -42,13 +42,19 @@ function readlsm{T}(::Type{T}, io::IO, delim='\t', comment='#')
 end
 
 function readlsm(io::IO, delim='\t')
-    readlsm(Float64, io, delim)
+    return readlsm(Float64, io, delim)
+end
+
+function readlsm{T}(::Type{T}, path::AbstractString, delim='\t')
+    lsm = nothing
+    open(path) do file
+        lsm = readlsm(T, file, delim)
+    end
+    return lsm
 end
 
 function readlsm(path::AbstractString, delim='\t')
-    open(path) do file
-        lsm = readlsm(Float64, file, delim)
-    end
+    return readlsm(Float64, path, delim)
 end
 
 end # module LabelledSquareMatrices

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -2,7 +2,10 @@ export readlsm
 
 const _default_delims = [' ','\t']
 
-"Reads a Labelled Square Matrix, returning a tuple of `(matrix, labels)`"
+"""
+Reads a Labelled Square Matrix from an IO stream or filename, returning a tuple
+of `(matrix, labels)`.
+"""
 function readlsm{T}(::Type{T}, io::IO, delim=_default_delims, comment='#')
     matrix = Matrix{T}()
     labels = UTF8String[]

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -1,0 +1,54 @@
+module LabelledSquareMatrices
+
+export readlsm
+
+"""
+Reads a Labelled Square Matrix
+
+Returns a tuple of `(matrix, labels)`
+"""
+function readlsm{T}(::Type{T}, io::IO, delim='\t', comment='#')
+    matrix = Matrix{T}()
+    labels = UTF8String[]
+    nitems = 0
+    row = 0
+    for line in eachline(io)
+        line = chomp(line)
+        if startswith(line, comment) || isempty(line)
+            continue  # skip comments and empty lines
+        end
+        if row > nitems
+            # Non-square error handled outside loop below
+            break
+        end
+        cells = split(line, delim)
+        if isempty(labels)
+            # header
+            append!(labels, map(UTF8String, cells[2:end]))
+            nitems = length(labels)
+            matrix = zeros(T, (nitems, nitems))
+            continue
+        end
+        row += 1
+        if cells[1] != labels[row]
+            error("Cell label mismatch. (at row $row)")
+        end
+        matrix[row, :] = map((s) -> parse(T, s), cells[2:end])
+    end
+    if row != nitems
+        error("Non-square matrix: read $row rows, with $nitems columns.")
+    end
+    return (matrix, labels)
+end
+
+function readlsm(io::IO, delim='\t')
+    readlsm(Float64, io, delim)
+end
+
+function readlsm(path::AbstractString, delim='\t')
+    open(path) do file
+        lsm = readlsm(Float64, file, delim)
+    end
+end
+
+end # module LabelledSquareMatrices

--- a/src/util/labelledmatrix.jl
+++ b/src/util/labelledmatrix.jl
@@ -3,8 +3,14 @@ export readlsm
 const _default_delims = [' ','\t']
 
 """
-Reads a Labelled Square Matrix from an IO stream or filename, returning a tuple
-of `(matrix, labels)`.
+    readlsm([type,] io, delim=[' ', '\t'], comment='#')
+    readlsm([type,] filepath, delim=[' ', '\t'], comment='#')
+
+Reads a Labelled Square Matrix from an IO stream or file, returning a pair of
+`(matrix, labels)`.
+
+One may specify the element type of the resulting matrix; this defaults to
+Float64.
 """
 function readlsm{T}(::Type{T}, io::IO, delim=_default_delims, comment='#')
     matrix = Matrix{T}()

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -9,89 +9,91 @@ end
 
 import Bio.Util: readlsm
 
-integral_matrix = """\
-\tA\tB\tC
-A\t1\t2\t4
-B\t2\t1\t2
-C\t4\t2\t1
-"""
-integral_matrix_expt = Float64[1 2 4; 2 1 2; 4 2 1;]
-commented_matrix = """\
-# This is a comment that gets skipped. The next blank line should also get
-# skipped.
-
-\tA\tB\tC
-A\t1\t2\t4
-B\t2\t1\t2
-C\t4\t2\t1
-"""
-spacy_matrix = """\
-# This matrix has heaps of extra spaces in the road, to try and trip up the
-# parser.
-
-   A  B  C 
-A 1 2          4
-B  2  1  2   
-C  4  2  1  
-"""
-
-float_matrix = """\
-\tA\tB\tC
-A\t1.0\t2.5\t4.5
-B\t2.5\t1.0\t2.5
-C\t4.5\t2.5\t1.0
-"""
-float_matrix_expt = Float64[1. 2.5 4.5; 2.5 1. 2.5; 4.5 2.5 1.;]
-
-good_matricies = [(float_matrix, float_matrix_expt),
-                  (integral_matrix, integral_matrix_expt),
-                  (commented_matrix, integral_matrix_expt),
-                  (spacy_matrix, integral_matrix_expt),
-                 ]
-
-bad_labels = """\
-\tA\tB\tC
-X\t1\t2\t4
-Y\t2\t1\t2
-Z\t4\t2\t1
-"""
-
-not_square = """\
-\tA\tB\tC
-A\t1\t2\t4
-"""
-
-missing_vals = """\
-\tA\tB\tC
-A\t1\t2\t4
-B\t2\t1\t2
-C\t4
-"""
-bad_matricies = [bad_labels,
-                 not_square,
-                 missing_vals,
-                 ]
-
-file_matricies = [("ints.tab", integral_matrix_expt),
-                  ("commented.tab", integral_matrix_expt),
-                 ]
-
-# Maps filename to labels
-NUC44 = UTF8String["A", "T", "G", "C", "S", "W", "R", "Y", "K", "M", "B", "V",
-                   "H", "D", "N"]
-BLOSUM = UTF8String["A", "R", "N", "D", "C", "Q", "E", "G", "H", "I", "L", "K",
-                    "M", "F", "P", "S", "T", "W", "Y", "V", "B", "Z", "X", "*"]
-subst_matricies = [("BLOSUM62", BLOSUM),
-                   ("NUC.4.4", NUC44),
-                 ]
-all_subst_matrices = ["BLOSUM45", "BLOSUM50", "BLOSUM62", "BLOSUM80",
-                      "BLOSUM90", "NUC.4.4", "PAM250", "PAM30", "PAM70"]
-
 @testset "LabelledSquareMatrices" begin
+
+    integral_matrix = """\
+    \tA\tB\tC
+    A\t1\t2\t4
+    B\t2\t1\t2
+    C\t4\t2\t1
+    """
+    integral_matrix_expt = Float64[1 2 4; 2 1 2; 4 2 1;]
+    commented_matrix = """\
+    # This is a comment that gets skipped. The next blank line should also get
+    # skipped.
+
+    \tA\tB\tC
+    A\t1\t2\t4
+    B\t2\t1\t2
+    C\t4\t2\t1
+    """
+    spacy_matrix = """\
+    # This matrix has heaps of extra spaces in the road, to try and trip up the
+    # parser.
+
+       A  B  C 
+    A 1 2          4
+    B  2  1  2   
+    C  4  2  1  
+    """
+
+    float_matrix = """\
+    \tA\tB\tC
+    A\t1.0\t2.5\t4.5
+    B\t2.5\t1.0\t2.5
+    C\t4.5\t2.5\t1.0
+    """
+    float_matrix_expt = Float64[1. 2.5 4.5; 2.5 1. 2.5; 4.5 2.5 1.;]
+
+    good_matricies = [(float_matrix, float_matrix_expt),
+                      (integral_matrix, integral_matrix_expt),
+                      (commented_matrix, integral_matrix_expt),
+                      (spacy_matrix, integral_matrix_expt),
+                     ]
+
+    bad_labels = """\
+    \tA\tB\tC
+    X\t1\t2\t4
+    Y\t2\t1\t2
+    Z\t4\t2\t1
+    """
+
+    not_square = """\
+    \tA\tB\tC
+    A\t1\t2\t4
+    """
+
+    missing_vals = """\
+    \tA\tB\tC
+    A\t1\t2\t4
+    B\t2\t1\t2
+    C\t4
+    """
+    bad_matricies = [bad_labels,
+                     not_square,
+                     missing_vals,
+                     ]
+
+    file_matricies = [("ints.tab", integral_matrix_expt),
+                      ("commented.tab", integral_matrix_expt),
+                     ]
+
+    # Maps filename to labels
+    NUC44 = UTF8String["A", "T", "G", "C", "S", "W", "R", "Y", "K", "M", "B", "V",
+                       "H", "D", "N"]
+    BLOSUM = UTF8String["A", "R", "N", "D", "C", "Q", "E", "G", "H", "I", "L", "K",
+                        "M", "F", "P", "S", "T", "W", "Y", "V", "B", "Z", "X", "*"]
+    subst_matricies = [("BLOSUM62", BLOSUM),
+                       ("NUC.4.4", NUC44),
+                     ]
+    all_subst_matrices = ["BLOSUM45", "BLOSUM50", "BLOSUM62", "BLOSUM80",
+                          "BLOSUM90", "NUC.4.4", "PAM250", "PAM30", "PAM70"]
+
     @testset "types" for T in [Int64, Float64]
         m, l = readlsm(T, IOBuffer(integral_matrix))
         expt_m = Array{T}(integral_matrix_expt)
         @test m == expt_m
+        @test eltype(m) == T
         @test l == UTF8String["A", "B", "C"]
     end
 

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -1,0 +1,74 @@
+module TestLSM
+
+if VERSION >= v"0.5-"
+    using Base.Test
+else
+    using BaseTestNext
+    const Test = BaseTestNext
+end
+
+integral_matrix = """\
+\tA\tB\tC
+A\t1\t2\t4
+B\t2\t1\t2
+C\t4\t2\t1
+"""
+integral_matrix_expt = Float64[1 2 4; 2 1 2; 4 2 1;]
+
+float_matrix = """\
+\tA\tB\tC
+A\t1.0\t2.5\t4.5
+B\t2.5\t1.0\t2.5
+C\t4.5\t2.5\t1.0
+"""
+float_matrix_expt = Float64[1. 2.5 4.5; 2.5 1. 2.5; 4.5 2.5 1.;]
+
+good_matricies = [(float_matrix, float_matrix_expt),
+                  (integral_matrix, integral_matrix_expt),
+                 ]
+
+bad_labels = """\
+\tA\tB\tC
+X\t1\t2\t4
+Y\t2\t1\t2
+Z\t4\t2\t1
+"""
+
+not_square = """\
+\tA\tB\tC
+A\t1\t2\t4
+"""
+
+missing_vals = """\
+\tA\tB\tC
+A\t1\t2\t4
+B\t2\t1\t2
+C\t4
+"""
+bad_matricies = [bad_labels,
+                 not_square,
+                 missing_vals,
+                 ]
+
+using Bio.LabelledSquareMatrices
+
+@testset "LabelledSquareMatrices" begin
+    @testset "types" for T in [Int64, Float64]
+        m, l = readlsm(T, IOBuffer(integral_matrix))
+        expt_m = Array{T}(integral_matrix_expt)
+        @test m == expt_m
+        @test l == UTF8String["A", "B", "C"]
+    end
+
+    @testset "good_matricies" for (mat, expected) in good_matricies
+        m, l = readlsm(IOBuffer(mat))
+        @test m == expected
+        @test l == UTF8String["A", "B", "C"]
+    end
+
+    @testset "bad_matricies" for mat in bad_matricies
+        @test_throws Exception readlsm(IOBuffer(mat))
+    end
+end
+
+end

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -14,6 +14,13 @@ B\t2\t1\t2
 C\t4\t2\t1
 """
 integral_matrix_expt = Float64[1 2 4; 2 1 2; 4 2 1;]
+commented_matrix = """\
+# This is a comment that gets skipped
+\tA\tB\tC
+A\t1\t2\t4
+B\t2\t1\t2
+C\t4\t2\t1
+"""
 
 float_matrix = """\
 \tA\tB\tC
@@ -25,6 +32,7 @@ float_matrix_expt = Float64[1. 2.5 4.5; 2.5 1. 2.5; 4.5 2.5 1.;]
 
 good_matricies = [(float_matrix, float_matrix_expt),
                   (integral_matrix, integral_matrix_expt),
+                  (commented_matrix, integral_matrix_expt),
                  ]
 
 bad_labels = """\

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -7,8 +7,8 @@ else
     const Test = BaseTestNext
 end
 
-using Bio.LabelledSquareMatrices,
-      TestFunctions
+import Bio.Util: readlsm
+using TestFunctions
 
 integral_matrix = """\
 \tA\tB\tC

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -7,6 +7,9 @@ else
     const Test = BaseTestNext
 end
 
+using Bio.LabelledSquareMatrices,
+      TestFunctions
+
 integral_matrix = """\
 \tA\tB\tC
 A\t1\t2\t4
@@ -15,7 +18,9 @@ C\t4\t2\t1
 """
 integral_matrix_expt = Float64[1 2 4; 2 1 2; 4 2 1;]
 commented_matrix = """\
-# This is a comment that gets skipped
+# This is a comment that gets skipped. The next blank line should also get
+# skipped.
+
 \tA\tB\tC
 A\t1\t2\t4
 B\t2\t1\t2
@@ -58,7 +63,9 @@ bad_matricies = [bad_labels,
                  missing_vals,
                  ]
 
-using Bio.LabelledSquareMatrices
+file_matricies = [("ints.tab", integral_matrix_expt),
+                  ("commented.tab", integral_matrix_expt),
+                 ]
 
 @testset "LabelledSquareMatrices" begin
     @testset "types" for T in [Int64, Float64]
@@ -76,6 +83,13 @@ using Bio.LabelledSquareMatrices
 
     @testset "bad_matricies" for mat in bad_matricies
         @test_throws Exception readlsm(IOBuffer(mat))
+    end
+
+    @testset "files" for (fname, expected) in file_matricies
+        fname = Pkg.dir("Bio", "test", "BioFmtSpecimens", "LSM", fname)
+        m, l = readlsm(fname)
+        @test m == expected
+        @test l == UTF8String["A", "B", "C"]
     end
 end
 

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -25,6 +25,15 @@ A\t1\t2\t4
 B\t2\t1\t2
 C\t4\t2\t1
 """
+spacy_matrix = """\
+# This matrix has heaps of extra spaces in the road, to try and trip up the
+# parser.
+
+   A  B  C 
+A 1 2          4
+B  2  1  2   
+C  4  2  1  
+"""
 
 float_matrix = """\
 \tA\tB\tC
@@ -37,6 +46,7 @@ float_matrix_expt = Float64[1. 2.5 4.5; 2.5 1. 2.5; 4.5 2.5 1.;]
 good_matricies = [(float_matrix, float_matrix_expt),
                   (integral_matrix, integral_matrix_expt),
                   (commented_matrix, integral_matrix_expt),
+                  (spacy_matrix, integral_matrix_expt),
                  ]
 
 bad_labels = """\

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -8,7 +8,6 @@ else
 end
 
 import Bio.Util: readlsm
-using TestFunctions
 
 integral_matrix = """\
 \tA\tB\tC
@@ -75,6 +74,9 @@ BLOSUM = UTF8String["A", "R", "N", "D", "C", "Q", "E", "G", "H", "I", "L", "K",
 subst_matricies = [("BLOSUM62", BLOSUM),
                    ("NUC.4.4", NUC44),
                  ]
+all_subst_matrices = ["BLOSUM45", "BLOSUM50", "BLOSUM62", "BLOSUM80",
+                      "BLOSUM90", "NUC.4.4", "PAM250", "PAM30", "PAM70"]
+
 @testset "LabelledSquareMatrices" begin
     @testset "types" for T in [Int64, Float64]
         m, l = readlsm(T, IOBuffer(integral_matrix))
@@ -106,6 +108,13 @@ subst_matricies = [("BLOSUM62", BLOSUM),
         m, l = readlsm(Int64, fname)
         @test size(m) == (N, N)
         @test l == labels
+    end
+
+    @testset "all_subst_matrices" for fname in all_subst_matrices
+        # Check that we can parse all matrices under the alignm module
+        fname = Pkg.dir("Bio", "src", "align", "data", "submat", fname)
+        m, l = readlsm(Int64, fname)
+        @test eltype(m) === Int64
     end
 end
 

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -67,6 +67,14 @@ file_matricies = [("ints.tab", integral_matrix_expt),
                   ("commented.tab", integral_matrix_expt),
                  ]
 
+# Maps filename to labels
+NUC44 = UTF8String["A", "T", "G", "C", "S", "W", "R", "Y", "K", "M", "B", "V",
+                   "H", "D", "N"]
+BLOSUM = UTF8String["A", "R", "N", "D", "C", "Q", "E", "G", "H", "I", "L", "K",
+                    "M", "F", "P", "S", "T", "W", "Y", "V", "B", "Z", "X", "*"]
+subst_matricies = [("BLOSUM62", BLOSUM),
+                   ("NUC.4.4", NUC44),
+                 ]
 @testset "LabelledSquareMatrices" begin
     @testset "types" for T in [Int64, Float64]
         m, l = readlsm(T, IOBuffer(integral_matrix))
@@ -90,6 +98,14 @@ file_matricies = [("ints.tab", integral_matrix_expt),
         m, l = readlsm(fname)
         @test m == expected
         @test l == UTF8String["A", "B", "C"]
+    end
+
+    @testset "subst_matrices" for (fname, labels) in subst_matricies
+        fname = Pkg.dir("Bio", "test", "BioFmtSpecimens", "LSM", fname)
+        N = length(labels)
+        m, l = readlsm(Int64, fname)
+        @test size(m) == (N, N)
+        @test l == labels
     end
 end
 

--- a/test/util/runtests.jl
+++ b/test/util/runtests.jl
@@ -1,3 +1,4 @@
+include("../TestFunctions.jl")
 include("indexing.jl")
-
+include("labelledmatrix.jl")
 include("windows.jl")


### PR DESCRIPTION
As talked about on gitter, this PR adds a parser for the common LSM format used to store e.g. distance matrices. The parser is currently a little ad-hoc, and adapted from @bicycle1885's substitution matrix parsers.

I will also attach a commit that removes that parser, and uses the `readlsm` function included here.

This is ready to review