### PR TITLE
remove deprecated names

### DIFF
--- a/src/seq/deprecated.jl
+++ b/src/seq/deprecated.jl
@@ -1,33 +1,6 @@
 import Base.@deprecate, Base.@deprecate_binding
 import Base.depwarn
 
-# DEPRECATED: defined for compatibility
-type NucleotideSequence{T<:Nucleotide} end
-
-@deprecate NucleotideSequence BioSequence
-@deprecate NucleotideSequence(::Type{DNANucleotide}) DNASequence
-@deprecate NucleotideSequence(::Type{RNANucleotide}) RNASequence
-@compat begin
-    (::Type{NucleotideSequence{DNANucleotide}})() = DNASequence()
-    (::Type{NucleotideSequence{RNANucleotide}})() = RNASequence()
-    (::Type{NucleotideSequence{DNANucleotide}})(
-        seq::Union{AbstractVector{DNANucleotide},AbstractString}) = DNASequence(seq)
-    (::Type{NucleotideSequence{RNANucleotide}})(
-        seq::Union{AbstractVector{RNANucleotide},AbstractString}) = RNASequence(seq)
-end
-Base.convert(::Type{NucleotideSequence}, seq::DNAKmer) = DNASequence(seq)
-Base.convert(::Type{NucleotideSequence}, seq::RNAKmer) = RNASequence(seq)
-Base.convert(::Type{NucleotideSequence{DNANucleotide}}, seq::Union{AbstractVector{DNANucleotide},AbstractString,DNAKmer}) = DNASequence(seq)
-Base.convert(::Type{NucleotideSequence{RNANucleotide}}, seq::Union{AbstractVector{RNANucleotide},AbstractString,RNAKmer}) = RNASequence(seq)
-
-@deprecate NucleotideCounts(seq) Composition(seq)
-@deprecate npositions(seq::BioSequence) ambiguous_positions(seq)
-
-@deprecate kmer Kmer
-@deprecate dnakmer DNAKmer
-@deprecate rnakmer RNAKmer
-
-
 # v0.2
 # ----
 


### PR DESCRIPTION
We should have removed these functions before the release of Bio.jl 0.3.