### PR TITLE
improve the performance of reverse_complement

### DIFF
--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -667,7 +667,7 @@ Base.reverse(seq::BioSequence) = reverse!(copy(seq))
         next = bitindex(seq, endof(seq))
         stop = bitindex(seq, 0)
         i = 0
-        while next - stop > 0
+        @inbounds while next - stop > 0
             r = offset(next) + $n
             x = seq.data[index(next)] << (64 - r)
             next -= r
@@ -765,7 +765,7 @@ Make a reversed complement sequence of `seq`.
 Ambiguous nucleotides are left as-is.
 """
 function reverse_complement{A<:Union{DNAAlphabet,RNAAlphabet}}(seq::BioSequence{A})
-    return reverse_complement!(copy(seq))
+    return complement!(reverse(seq))
 end
 
 


### PR DESCRIPTION
With this change, `reverse_complement` became ~7x faster.

Before (master):
```
julia> srand(1234);

julia> seq = randdnaseq(10_000)
10000nt DNA Sequence:
GTGCTTACAGGAATGACGATTTTTTAACACTCAAACGCCTAGCC…TGACTAGCCATTTGTCACCCAACACGGGCGAGCGGGCATGTGTA

julia> @benchmark reverse_complement(seq)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  5.02 kb
  allocs estimate:  2
  minimum time:     38.07 μs (0.00% GC)
  median time:      38.37 μs (0.00% GC)
  mean time:        42.33 μs (0.00% GC)
  maximum time:     864.49 μs (0.00% GC)

```

After:
```
julia> srand(1234);

julia> seq = randdnaseq(10_000)
10000nt DNA Sequence:
GTGCTTACAGGAATGACGATTTTTTAACACTCAAACGCCTAGCC…TGACTAGCCATTTGTCACCCAACACGGGCGAGCGGGCATGTGTA

julia> @benchmark reverse_complement(seq)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     7
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  5.02 kb
  allocs estimate:  2
  minimum time:     4.93 μs (0.00% GC)
  median time:      5.24 μs (0.00% GC)
  mean time:        6.52 μs (8.85% GC)
  maximum time:     444.78 μs (98.57% GC)

```