### PR TITLE
improve the performance of gc_content(::Kmer)

### DIFF
--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -219,6 +219,18 @@ function Base.next{T, K}(it::KmerNeighborIterator{T, K}, i)
     return Kmer{T,K}((UInt64(it.x) << 2) | i), i + 1
 end
 
+
+# Counters
+# --------
+
+function gc_content{T,k}(kmer::Kmer{T,k})
+    if k == 0
+        return 0.0
+    else
+        return (count_g(kmer) + count_c(kmer)) / k
+    end
+end
+
 function count_a{T,k}(kmer::Kmer{T,k})
     return count_a(reinterpret(UInt64, kmer)) - (32 - k)
 end

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -1545,7 +1545,11 @@ end
         @test gc_content(dna"CGGC") === 1.0
         @test gc_content(dna"ACATTGTGTATAACAAAAGG") === 6 / 20
 
+        @test gc_content(DNAKmer("")) === 0.0
+        @test gc_content(DNAKmer("AATA")) === 0.0
         @test gc_content(DNAKmer("ACGT")) === 0.5
+        @test gc_content(DNAKmer("CGGC")) === 1.0
+        @test gc_content(DNAKmer("ACATTGTGTATAACAAAAGG")) === 6 / 20
 
         @test gc_content(rna"") === 0.0
         @test gc_content(rna"AAUA") === 0.0
@@ -1553,7 +1557,11 @@ end
         @test gc_content(rna"CGGC") === 1.0
         @test gc_content(rna"ACAUUGUGUAUAACAAAAGG") === 6 / 20
 
+        @test gc_content(RNAKmer("")) === 0.0
+        @test gc_content(RNAKmer("AAUA")) === 0.0
         @test gc_content(RNAKmer("ACGU")) === 0.5
+        @test gc_content(RNAKmer("CGGC")) === 1.0
+        @test gc_content(RNAKmer("ACAUUGUGUAUAACAAAAGG")) === 6 / 20
 
         @test_throws Exception gc_content(aa"ARN")
     end


### PR DESCRIPTION
Before (master):
```
julia> @benchmark gc_content($(DNAKmer("ACGT"^8)))
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     992
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     37.00 ns (0.00% GC)
  median time:      47.00 ns (0.00% GC)
  mean time:        47.93 ns (0.00% GC)
  maximum time:     1.94 μs (0.00% GC)

```

After:
```
julia> @benchmark gc_content($(DNAKmer("ACGT"^8)))
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1000
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     6.00 ns (0.00% GC)
  median time:      6.00 ns (0.00% GC)
  mean time:        6.02 ns (0.00% GC)
  maximum time:     60.00 ns (0.00% GC)

```