### PR TITLE
improve the performance of sequence type prediction

### DIFF
--- a/src/seq/predict.jl
+++ b/src/seq/predict.jl
@@ -6,12 +6,12 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-# predict sequence type based on character frequencies in `seq[start:stop]`
+# Predict sequence type based on character frequencies in `seq[start:stop]`.
 function predict(seq::Vector{UInt8}, start, stop)
     # count characters
     a = c = g = t = u = n = alpha = 0
     for i in start:stop
-        x = seq[i]
+        @inbounds x = seq[i]
         if x == 0x41 || x == 0x61
             a += 1
         elseif x == 0x43 || x == 0x63
@@ -27,6 +27,10 @@ function predict(seq::Vector{UInt8}, start, stop)
         end
         if 0x41 ≤ x ≤ 0x5a || 0x61 ≤ x ≤ 0x7a
             alpha += 1
+            if alpha ≥ 300 && t + u > 0 && a + c + g + t + u + n == alpha
+                # pretty sure that the sequence is either DNA or RNA
+                break
+            end
         end
     end
 


### PR DESCRIPTION
This improves the performance of parsing a FASTA file when the sequence is a long DNA or RNA sequence like chromosomal sequences.

Benchmark results of parsing chromosome 1 of human are:

Before (master):
```
  6.017943 seconds (34.78 M allocations: 801.361 MB, 1.46% gc time)
```

After:
```
  3.909558 seconds (34.78 M allocations: 801.361 MB, 2.55% gc time)
```