### PR TITLE
improve the performance of encoding ASCII string

### DIFF
--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -998,14 +998,15 @@ function encode_copy!{A<:Union{DNAAlphabet{4},RNAAlphabet{4}}}(
             check |= y
         end
         if check & 0x80 != 0
-            for d in 0x00:0x0f
+            # invalid byte(s) is detected
+            for d in 0:D-1
                 if !isvalid(charmap[src[i+d]+1])
                     error("cannot encode $(src[i+d])")
                 end
             end
         end
         dst.data[index(next)] = x
-        i += Int(D)
+        i += D
         next += 64
     end
 

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -373,7 +373,7 @@ end
             for nt in alphabet(DNANucleotide)
                 @test encode(DNAAlphabet{4}, nt) === reinterpret(UInt8, nt)
             end
-            @test_throws EncodeError encode(DNAAlphabet{4}, Seq.DNA_INVALID)
+            @test_throws EncodeError encode(DNAAlphabet{4}, reinterpret(DNANucleotide, 0b10000))
         end
         @testset "RNA" begin
             encode = Seq.encode
@@ -392,7 +392,7 @@ end
             for nt in alphabet(RNANucleotide)
                 @test encode(RNAAlphabet{4}, nt) === reinterpret(UInt8, nt)
             end
-            @test_throws EncodeError encode(RNAAlphabet{4}, Seq.RNA_INVALID)
+            @test_throws EncodeError encode(RNAAlphabet{4}, reinterpret(RNANucleotide, 0b10000))
         end
     end
 


### PR DESCRIPTION
This improves the performance of encoding an ASCII string into a DNA/RNA sequence, which also improves the performance of parsing a FASTA file.

Before (#275):
```
 3.909558 seconds (34.78 M allocations: 801.361 MB, 2.55% gc time)
```

After:
```
  3.013747 seconds (34.78 M allocations: 801.361 MB, 3.01% gc time)
```