### PR TITLE
Extra refinement to `seqmatrix`

### DIFF
--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -1033,7 +1033,7 @@ end
 # -------------------
 
 """
-    seqmatrix{A<:Alphabet}(vseq::Vector{BioSequence{A}}, major=:seq|:site)
+    seqmatrix{A<:Alphabet}(vseq::Vector{BioSequence{A}}, major::Symbol)
 
 Construct a matrix of nucleotides or amino acids from a vector of `BioSequence`s.
 
@@ -1076,7 +1076,7 @@ julia> seqmatrix(seqs, :site)
   DNA_A  DNA_T  DNA_C  DNA_G
 ```
 """
-function seqmatrix{A<:Alphabet}(vseq::AbstractVector{BioSequence{A}}, major=:site)
+function seqmatrix{A<:Alphabet}(vseq::AbstractVector{BioSequence{A}}, major::Symbol)
     l = length(vseq[1])
     nseqs = length(vseq)
     @inbounds for i in 2:nseqs

--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -1080,7 +1080,7 @@ function seqmatrix{A<:Alphabet}(vseq::AbstractVector{BioSequence{A}}, major::Sym
     l = length(vseq[1])
     nseqs = length(vseq)
     @inbounds for i in 2:nseqs
-        length(vseq[i]) != l || throw(ArgumentError("Sequences in vseq must be of same length"))
+        length(vseq[i]) == l || throw(ArgumentError("Sequences in vseq must be of same length"))
     end
     if major == :site
         nsites = minimum([length(seq) for seq in vseq])

--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -1076,20 +1076,23 @@ julia> seqmatrix(seqs, :site)
   DNA_A  DNA_T  DNA_C  DNA_G
 ```
 """
-function seqmatrix{A<:Alphabet}(vseq::Vector{BioSequence{A}}, major=:site)
+function seqmatrix{A<:Alphabet}(vseq::AbstractVector{BioSequence{A}}, major=:site)
+    l = length(vseq[1])
+    nseqs = length(vseq)
+    @inbounds for i in 2:nseqs
+        length(vseq[i]) != l | throw(ArgumentError("Sequences in vseq must be of same length"))
+    end
     if major == :site
         nsites = minimum([length(seq) for seq in vseq])
-        nseqs = length(vseq)
         mat = Matrix{eltype(A)}(nseqs, nsites)
-        for seq in 1:nseqs, site in 1:nsites
+        @inbounds for seq in 1:nseqs, site in 1:nsites
             mat[seq, site] = vseq[seq][site]
         end
         return mat
     elseif major == :seq
         nsites = minimum([length(seq) for seq in vseq])
-        nseqs = length(vseq)
         mat = Matrix{eltype(A)}(nsites, nseqs)
-        for seq in 1:nseqs, site in 1:nsites
+        @inbounds for seq in 1:nseqs, site in 1:nsites
             mat[site, seq] = vseq[seq][site]
         end
         return mat

--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -1080,7 +1080,7 @@ function seqmatrix{A<:Alphabet}(vseq::AbstractVector{BioSequence{A}}, major::Sym
     l = length(vseq[1])
     nseqs = length(vseq)
     @inbounds for i in 2:nseqs
-        length(vseq[i]) != l | throw(ArgumentError("Sequences in vseq must be of same length"))
+        length(vseq[i]) != l || throw(ArgumentError("Sequences in vseq must be of same length"))
     end
     if major == :site
         nsites = minimum([length(seq) for seq in vseq])

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -790,38 +790,38 @@ end
         rnathrow = [rna"AAA", rna"UUU", rna"CCCUUU", rna"GGG"]
 
         prot = [aa"AMG", aa"AMG", aa"AMG", aa"AMG"]
-        
+
         sitemajdna = [
-            DNA_A  DNA_A  DNA_A;
-            DNA_T  DNA_T  DNA_T;
-            DNA_C  DNA_C  DNA_C;
+            DNA_A  DNA_A  DNA_A
+            DNA_T  DNA_T  DNA_T
+            DNA_C  DNA_C  DNA_C
             DNA_G  DNA_G  DNA_G
         ]
         seqmajdna = [
-            DNA_A  DNA_T  DNA_C  DNA_G;
-            DNA_A  DNA_T  DNA_C  DNA_G;
+            DNA_A  DNA_T  DNA_C  DNA_G
+            DNA_A  DNA_T  DNA_C  DNA_G
             DNA_A  DNA_T  DNA_C  DNA_G
         ]
         sitemajrna = [
-            RNA_A  RNA_A  RNA_A;
-            RNA_U  RNA_U  RNA_U;
-            RNA_C  RNA_C  RNA_C;
+            RNA_A  RNA_A  RNA_A
+            RNA_U  RNA_U  RNA_U
+            RNA_C  RNA_C  RNA_C
             RNA_G  RNA_G  RNA_G
         ]
         seqmajrna = [
-            RNA_A  RNA_U  RNA_C  RNA_G;
-            RNA_A  RNA_U  RNA_C  RNA_G;
+            RNA_A  RNA_U  RNA_C  RNA_G
+            RNA_A  RNA_U  RNA_C  RNA_G
             RNA_A  RNA_U  RNA_C  RNA_G
         ]
         sitemajaa = [
-            AA_A AA_M AA_G;
-            AA_A AA_M AA_G;
-            AA_A AA_M AA_G;
+            AA_A AA_M AA_G
+            AA_A AA_M AA_G
+            AA_A AA_M AA_G
             AA_A AA_M AA_G
         ]
         seqmajaa = [
-            AA_A AA_A AA_A AA_A;
-            AA_M AA_M AA_M AA_M;
+            AA_A AA_A AA_A AA_A
+            AA_M AA_M AA_M AA_M
             AA_G AA_G AA_G AA_G
         ]
 

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -783,9 +783,14 @@ end
     end
 
     @testset "Conversion to Matrices" begin
-        dna = [dna"AAA", dna"TTTAAA", dna"CCC", dna"GGG"]
-        rna = [rna"AAA", rna"UUU", rna"CCCUUU", rna"GGG"]
+        dna = [dna"AAA", dna"TTT", dna"CCC", dna"GGG"]
+        dnathrow = [dna"AAA", dna"TTTAAA", dna"CCC", dna"GGG"]
+
+        rna = [rna"AAA", rna"UUU", rna"CCC", rna"GGG"]
+        rnathrow = [rna"AAA", rna"UUU", rna"CCCUUU", rna"GGG"]
+
         prot = [aa"AMG", aa"AMG", aa"AMG", aa"AMG"]
+        
         sitemajdna = [
             DNA_A  DNA_A  DNA_A;
             DNA_T  DNA_T  DNA_T;
@@ -827,6 +832,10 @@ end
         @test seqmatrix(dna, :seq) == seqmajdna
         @test seqmatrix(rna, :seq) == seqmajrna
         @test seqmatrix(prot, :seq) == seqmajaa
+
+        @test_throws ArgumentError seqmatrix(dnathrow, :site)
+        @test_throws ArgumentError seqmatrix(rnathrow, :seq)
+        @test_throws ArgumentError seqmatrix(dna, :lol)
 
     end
 


### PR DESCRIPTION
@bicycle1885 - Implemented your post merge suggestions :+1: 
* Added sequence length checking behaviour to `seqmatrix`.
* Added tests of throw cases.
* Loosening the type constraint of `vseq` to `AbstractVector{BioSequence{A}}`.
* `major` is now just a parameter, not an optional one.