### PR TITLE
force inlining of sequence iterator

### DIFF
--- a/src/seq/sequence.jl
+++ b/src/seq/sequence.jl
@@ -36,14 +36,22 @@ Base.eachindex(seq::Sequence) = 1:endof(seq)
     throw(BoundsError(seq, i))
 end
 
-function Base.getindex(seq::Sequence, i::Integer)
+@inline function Base.getindex(seq::Sequence, i::Integer)
     @boundscheck checkbounds(seq, i)
     return inbounds_getindex(seq, i)
 end
 
-Base.start(seq::Sequence) = 1
-Base.done(seq::Sequence, i) = i > endof(seq)
-Base.next(seq::Sequence, i) = inbounds_getindex(seq, i), i + 1
+@inline function Base.start(seq::Sequence)
+    return 1
+end
+
+@inline function Base.done(seq::Sequence, i)
+    return i > endof(seq)
+end
+
+@inline function Base.next(seq::Sequence, i)
+    return inbounds_getindex(seq, i), i + 1
+end
 
 
 # Comparison
@@ -122,6 +130,7 @@ function gc_content(seq::Sequence)
         return gc / length(seq)
     end
 end
+
 
 # Predicates
 # ----------


### PR DESCRIPTION
This forces the Julia compiler to inline functions related to sequence iterator. I don't know why but it significantly improves the performance if iteration. Julia 0.5 RC3 seems to have some regressions here.

```julia
using Bio.Seq
using BenchmarkTools

function foo(seq)
    n = 0
    for i in 1:endof(seq)
        n += seq[i] == DNA_A
    end
    return n
end

function bar(seq)
    n = 0
    for i in 1:endof(seq)
        @inbounds n += seq[i] == DNA_A
    end
    return n
end

function baz(seq)
    n = 0
    for nt in seq
        n += nt == DNA_A
    end
    return n
end

const seq = randdnaseq(10000)
println(@benchmark foo($seq))
println(@benchmark bar($seq))
println(@benchmark baz($seq))
```

Before:
```
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     75.71 μs (0.00% GC)
  median time:      83.90 μs (0.00% GC)
  mean time:        91.17 μs (0.00% GC)
  maximum time:     10.17 ms (0.00% GC)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     75.69 μs (0.00% GC)
  median time:      83.90 μs (0.00% GC)
  mean time:        89.70 μs (0.00% GC)
  maximum time:     6.59 ms (0.00% GC)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     75.35 μs (0.00% GC)
  median time:      76.12 μs (0.00% GC)
  mean time:        87.93 μs (0.00% GC)
  maximum time:     15.23 ms (0.00% GC)

```

After:
```
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     22.63 μs (0.00% GC)
  median time:      25.07 μs (0.00% GC)
  mean time:        26.67 μs (0.00% GC)
  maximum time:     503.15 μs (0.00% GC)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     20.21 μs (0.00% GC)
  median time:      22.70 μs (0.00% GC)
  mean time:        24.68 μs (0.00% GC)
  maximum time:     11.18 ms (0.00% GC)
BenchmarkTools.Trial:
  samples:          10000
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  0.00 bytes
  allocs estimate:  0
  minimum time:     19.41 μs (0.00% GC)
  median time:      21.50 μs (0.00% GC)
  mean time:        23.25 μs (0.00% GC)
  maximum time:     462.55 μs (0.00% GC)
```