### PR TITLE
add left/rightposition accessors to Interval

### DIFF
--- a/src/align/hts/bam/record.jl
+++ b/src/align/hts/bam/record.jl
@@ -139,7 +139,7 @@ Return the leftmost mapping position of `rec`.
 
 The index is 1-based and will be 0 for an alignment without mapping position.
 """
-function leftposition(rec::BAMRecord)
+function Bio.Intervals.leftposition(rec::BAMRecord)
     return rec.pos + 1
 end
 
@@ -148,7 +148,7 @@ end
 
 Return the rightmost mapping position of `rec`.
 """
-function rightposition(rec::BAMRecord)
+function Bio.Intervals.rightposition(rec::BAMRecord)
     return Int32(leftposition(rec) + alignment_length(rec) - 1)
 end
 

--- a/src/align/hts/sam/record.jl
+++ b/src/align/hts/sam/record.jl
@@ -97,11 +97,11 @@ function nextrefname(rec::SAMRecord)
     return rec.next_refname
 end
 
-function leftposition(rec::SAMRecord)
+function Bio.Intervals.leftposition(rec::SAMRecord)
     return rec.pos
 end
 
-function rightposition(rec::SAMRecord)
+function Bio.Intervals.rightposition(rec::SAMRecord)
     return leftposition(rec) + alignment_length(rec) - 1
 end
 

--- a/src/intervals/Intervals.jl
+++ b/src/intervals/Intervals.jl
@@ -11,6 +11,8 @@ module Intervals
 export
     Strand,
     Interval,
+    leftposition,
+    rightposition,
     IntervalCollection,
     IntervalStream,
     STRAND_NA,

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -42,6 +42,24 @@ end
 seqname(i::Interval) = i.seqname
 strand(i::Interval) = i.strand
 
+"""
+    leftposition(i::Interval)
+
+Return the leftmost position of `i`.
+"""
+function leftposition(i::Interval)
+    return i.first
+end
+
+"""
+    rightposition(i::Interval)
+
+Return the rightmost position of `i`.
+"""
+function rightposition(i::Interval)
+    return i.last
+end
+
 IntervalTrees.first(i::Interval) = i.first
 IntervalTrees.last(i::Interval) = i.last
 
@@ -100,7 +118,16 @@ function isoverlapping{S, T}(a::Interval{S}, b::Interval{T})
 end
 
 function Base.show(io::IO, i::Interval)
-    print(io, i.seqname, ":", i.first, "-", i.last, "    ", i.strand, "    ", i.metadata)
+    if get(io, :compact, false)
+        print(io, i.seqname, ":", i.first, "-", i.last, "  ", i.strand, "  ", i.metadata)
+    else
+        println(io, summary(i), ':')
+        println(io, "  sequence name: ", i.seqname)
+        println(io, "  leftmost position: ", i.first)
+        println(io, "  rightmost position: ", i.last)
+        println(io, "  strand: ", i.strand)
+          print(io, "  metadata: ", i.metadata)
+    end
 end
 
 """

--- a/test/intervals/runtests.jl
+++ b/test/intervals/runtests.jl
@@ -165,8 +165,8 @@ end
     @testset "Constructor" begin
         i = Interval("chr1", 10, 20)
         @test seqname(i) == "chr1"
-        @test first(i) == 10
-        @test last(i) == 20
+        @test leftposition(i) == 10
+        @test rightposition(i) == 20
         @test strand(i) == STRAND_BOTH
 
         i1 = Interval("chr1", 10, 20, '+')


### PR DESCRIPTION
This adds `leftposition` and `rightposition` accessor functions to the `Interval` type. Currently, we extend the `Base.first` and `Base.last` functions to access left/rightmost position of an interval. However, `Base.first` and `Base.last` already have well-defined semantics in the standard library and I think we should not abuse them for the interval types. Along with #297, we can always use the `leftposition` and `rightposition` functions for interval-like objects.