### PR TITLE
`flagmutations` for seqmatrixes

### DIFF
--- a/docs/src/man/var.md
+++ b/docs/src/man/var.md
@@ -7,7 +7,7 @@ DocTestSetup = quote
 end
 ```
 
-## Counting mutations
+## Identifying and counting mutations
 
 You can count the numbers of different types of mutations in a pairwise manner
 for a set of nucleotide sequences.
@@ -23,7 +23,7 @@ TransitionMutation
 TransversionMutation
 ```
 
-### `count_mutations` method
+### The `count_mutations` method
 
 Mutations are counted using the `count_mutations` method.
 The method outputs a tuple. The first value is the number of mutations counted.
@@ -49,6 +49,12 @@ count_mutations(TransversionMutation, [rna"AUCGAUCG", rna"ACCGAUCG"])
 count_mutations(TransitionMutation, TransversionMutation, [rna"AUCGAUCG", rna"ACCGAUCG"])
 ```
 
+### The `is_mutation` method
+
+```@docs
+is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
+```
+
 ## Computing evolutionary and genetic distances
 
 Just as you can count the number of mutations between two nucleotide sequences,
@@ -69,4 +75,8 @@ Kimura80
 
 ```@docs
 distance
+distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
+distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}})
+distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}})
+distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}})
 ```

--- a/src/var/Var.jl
+++ b/src/var/Var.jl
@@ -12,13 +12,15 @@ using Bio.Seq
 
 export
 
-    # Mutation counting
+    # Mutation types
     MutationType,
     AnyMutation,
     TransitionMutation,
     TransversionMutation,
 
+    # Identifying and counting mutations
     count_mutations,
+    is_mutation,
 
     # Genetic and Evolutionary distances
     EvolutionaryDistance,

--- a/src/var/Var.jl
+++ b/src/var/Var.jl
@@ -21,6 +21,7 @@ export
     # Identifying and counting mutations
     count_mutations,
     is_mutation,
+    flagmutations,
 
     # Genetic and Evolutionary distances
     EvolutionaryDistance,

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -89,7 +89,7 @@ end
 
 
 """
-    is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
+    flagmutations{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
 
 For every pair of sequences, flag which base positions are mutations of type `T`.
 
@@ -141,7 +141,7 @@ julia> m = seqmatrix(dnas, :seq)
   DNA_A    DNA_T
   DNA_A    DNA_C
 
-julia> r = is_mutation(AnyMutation, m)
+julia> r = flagmutations(AnyMutation, m)
 (
 Bool[false; false; … ; true; true],
 
@@ -172,10 +172,10 @@ julia> r[1]
 ```
 
 In the above example of two sequences, positions 3:4, 7:8 are mutations and
-positions 1:2, 5, 19:20 are not mutations. 
+positions 1:2, 5, 19:20 are not mutations.
 
 """
-function is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
+function flagmutations{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
     seqsize, nseqs = size(seqs)
     ismutant = Matrix{Bool}(seqsize, binomial(nseqs, 2))
     isambiguous = Matrix{Bool}(seqsize, binomial(nseqs, 2))
@@ -311,6 +311,10 @@ function count_mutations{A<:Nucleotide}(::Type{TransitionMutation}, ::Type{Trans
         end
     end
     return ntransition, ntransversion, lengths
+end
+
+function count_mutations{A<:Nucleotide}(::Type{TransversionMutation}, ::Type{TransitionMutation}, seqs::Matrix{A})
+    return count_mutations(TransitionMutation, TransversionMutation, seqs)
 end
 
 """

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -91,16 +91,94 @@ end
 """
     is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
 
+For every pair of sequences, flag which base positions are mutations of type `T`.
+
+This function returns a tuple of two matrices. Both matrices contain logical
+values, and contain a column for every pairwise combination of sequences,
+and a number of rows equal to the length of the aligned sequences.
+
+For the first matrix, for a cell of a given column,
+a value of `true` indicates that there is a mutation of type `T` between two
+sequences at that base position.
+
+For the second matrix, for a cell of a given column,
+a value of `true` indicates that there is an ambiguous base in either of the two
+sequences at that base position, consequently it is not possible to conclude
+whether there is a mutation at that base position or not.
 
 **Note: This method assumes that the sequences are stored in the `Matrix{N}`
 provided as `seqs` in sequence major order i.e. each column of the matrix is one
 complete nucleotide sequence.**
+
+# Example
+
+```julia
+dnas = [dna"ATTG-ACCTGGNTTTCCGAA", dna"A-ACAGAGTATACRGTCGTC"]
+2-element Array{Bio.Seq.BioSequence{Bio.Seq.DNAAlphabet{4}},1}:
+ ATTG-ACCTGGNTTTCCGAA
+ A-ACAGAGTATACRGTCGTC
+
+julia> m = seqmatrix(dnas, :seq)
+20×2 Array{Bio.Seq.DNANucleotide,2}:
+  DNA_A    DNA_A
+  DNA_T    DNA_Gap
+  DNA_T    DNA_A
+  DNA_G    DNA_C
+  DNA_Gap  DNA_A
+  DNA_A    DNA_G
+  DNA_C    DNA_A
+  DNA_C    DNA_G
+  DNA_T    DNA_T
+  DNA_G    DNA_A
+  DNA_G    DNA_T
+  DNA_N    DNA_A
+  DNA_T    DNA_C
+  DNA_T    DNA_R
+  DNA_T    DNA_G
+  DNA_C    DNA_T
+  DNA_C    DNA_C
+  DNA_G    DNA_G
+  DNA_A    DNA_T
+  DNA_A    DNA_C
+
+julia> r = is_mutation(AnyMutation, m)
+(
+Bool[false; false; … ; true; true],
+
+Bool[false; true; … ; false; false])
+
+julia> r[1]
+20×1 Array{Bool,2}:
+ false
+ false
+  true
+  true
+ false
+  true
+  true
+  true
+ false
+  true
+  true
+ false
+  true
+ false
+  true
+  true
+ false
+ false
+  true
+  true
+```
+
+In the above example of two sequences, positions 3:4, 7:8 are mutations and
+positions 1:2, 5, 19:20 are not mutations. 
+
 """
 function is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
     seqsize, nseqs = size(seqs)
     ismutant = Matrix{Bool}(seqsize, binomial(nseqs, 2))
     isambiguous = Matrix{Bool}(seqsize, binomial(nseqs, 2))
-
     col = 1
     @inbounds for i1 in 1:nseqs
         for i2 in i1+1:nseqs
@@ -115,9 +193,7 @@ function is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
             col += 1
         end
     end
-
     return ismutant, isambiguous
-
 end
 
 

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -108,7 +108,7 @@ function is_mutation{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N})
                 s1 = seqs[(i1 - 1) * seqsize + s]
                 s2 = seqs[(i2 - 1) * seqsize + s]
                 isamb = is_ambiguous_strict(s1, s2)
-                ismut = is_mutation(T, s1, s2)
+                ismut = is_mutation(M, s1, s2)
                 isambiguous[(col - 1) * seqsize + s] = isamb
                 ismutant[(col - 1) * seqsize + s] = !isamb & ismut
             end

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -33,8 +33,8 @@ using Bio.Var
     @test count_mutations(TransversionMutation, TransitionMutation, m1) == count_mutations(TransversionMutation, TransitionMutation, m2) == ([4], [8], [16])
 
     ans = Bool[false, false, true, true, false, true, true, true, false, true, true, false, true, false, true, true, false, false, true, true]
-    @test is_mutation(AnyMutation, m1)[1] == ans
-    @test is_mutation(AnyMutation, m2)[1] == ans
+    @test flagmutations(AnyMutation, m1)[1][:,1] == ans
+    @test flagmutations(AnyMutation, m2)[1][:,1] == ans
 
 
 end

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -16,14 +16,26 @@ using Bio.Var
     # every possible transversion (8), and 2 gapped sites and 2 ambiguous sites.
     # This leaves 4 sites non-mutated/conserved.
     dnas = [dna"ATTG-ACCTGGNTTTCCGAA", dna"A-ACAGAGTATACRGTCGTC"]
+    m1 = seqmatrix(dnas, :seq)
 
     rnas = [rna"AUUG-ACCUGGNUUUCCGAA", rna"A-ACAGAGUAUACRGUCGUC"]
+    m2 = seqmatrix(rnas, :seq)
 
     @test count_mutations(AnyMutation, dnas) == count_mutations(AnyMutation, rnas) == ([12], [16])
+    @test count_mutations(AnyMutation, m1) == count_mutations(AnyMutation, m2) == ([12], [16])
     @test count_mutations(TransitionMutation, dnas) == count_mutations(TransitionMutation, rnas) == ([4], [16])
+    @test count_mutations(TransitionMutation, m1) == count_mutations(TransitionMutation, m2) == ([4], [16])
     @test count_mutations(TransversionMutation, dnas) == count_mutations(TransversionMutation, rnas) == ([8], [16])
+    @test count_mutations(TransversionMutation, m1) == count_mutations(TransversionMutation, m2) == ([8], [16])
     @test count_mutations(TransitionMutation, TransversionMutation, dnas) == count_mutations(TransitionMutation, TransversionMutation, rnas) == ([4], [8], [16])
+    @test count_mutations(TransitionMutation, TransversionMutation, m1) == count_mutations(TransitionMutation, TransversionMutation, m2) == ([4], [8], [16])
     @test count_mutations(TransversionMutation, TransitionMutation, dnas) == count_mutations(TransversionMutation, TransitionMutation, rnas) == ([4], [8], [16])
+    @test count_mutations(TransversionMutation, TransitionMutation, m1) == count_mutations(TransversionMutation, TransitionMutation, m2) == ([4], [8], [16])
+
+    ans = Bool[false, false, true, true, false, true, true, true, false, true, true, false, true, false, true, true, false, false, true, true]
+    @test is_mutation(AnyMutation, m1)[1] == ans
+    @test is_mutation(AnyMutation, m2)[1] == ans
+
 
 end
 


### PR DESCRIPTION
Adds an `is_mutation` method for seqmatrices. 

Produces boolean matrixes indicating which positions are mutated and which are not for every pairwise combination of sequences. 

This is useful for e.g. if you're doing sliding window distance computations or mutation counting computations to find hotspots across sequences, regions of high/low divergence, and so on, as all you need to do is slide across these boolean matrices and so `sum` operations.