### PR TITLE
Majority vote improvement

### DIFF
--- a/src/seq/bioseq.jl
+++ b/src/seq/bioseq.jl
@@ -1203,8 +1203,9 @@ function majorityvote{A<:NucleotideAlphabet}(seqs::AbstractVector{BioSequence{A}
     nsites = size(mat, 2)
     nseqs = size(mat, 1)
     result = BioSequence{A}(nsites)
+    votes = Array{Int}(16)
     @inbounds for site in 1:nsites
-        votes = zeros(Int, 16)
+        fill!(votes, 0)
         for seq in 1:nseqs
             nuc = mat[seq, site]
             votes[1] += nuc == 0x00


### PR DESCRIPTION
Modifications to the majority vote algorithm greatly improving performance by removing branching/special cases, and greatly decreasing the amount of memory allocation.

Benchmarks:
Before:
```julia
julia> @benchmark consensus = majorityvote(sequences)
BenchmarkTools.Trial: 
  samples:          4
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  537.20 mb
  allocs estimate:  6376133
  minimum time:     1.29 s (6.60% GC)
  median time:      1.37 s (10.87% GC)
  mean time:        1.37 s (10.95% GC)
  maximum time:     1.46 s (14.98% GC)

julia> @time consensus = majorityvote(sequences)
  1.279496 seconds (6.38 M allocations: 537.197 MB, 7.12% gc time)
398508nt DNA Sequence:
GCTACTCGTCGTGTCGAAGTCGGCCGCGGCGCGTTTGTA…AGAATCCAAAATACAACGGCAATGGAAACAATAAATTAA
```

After:

```julia
julia> @benchmark consensus = majorityvote(sequences)
BenchmarkTools.Trial: 
  samples:          12
  evals/sample:     1
  time tolerance:   5.00%
  memory tolerance: 1.00%
  memory estimate:  32.49 mb
  allocs estimate:  6
  minimum time:     410.76 ms (0.80% GC)
  median time:      423.19 ms (0.77% GC)
  mean time:        423.09 ms (0.74% GC)
  maximum time:     436.22 ms (0.67% GC)

julia> @time consensus = majorityvote(sequences)
  0.440250 seconds (20 allocations: 32.495 MB, 2.87% gc time)
398508nt DNA Sequence:
GCTACTCGTCGTGTCGAAGTCGGCCGCGGCGCGTTTGTA…AGAATCCAAAATACAACGGCAATGGAAACAATAAATTAA
```

Very simple changes really, with no effect on the output of the function. So I'd like to merge rapidly once builds pass if no objections.