### PR TITLE
make qualities(::BAMRecord) return a vector of Int8

### DIFF
--- a/src/align/hts/bam/record.jl
+++ b/src/align/hts/bam/record.jl
@@ -269,7 +269,7 @@ Return base qualities of the alignment `rec`.
 function qualities(rec::BAMRecord)
     seqlen = sequence_length(rec)
     offset = seqname_length(rec) + n_cigar_op(rec) * 4 + cld(seqlen, 2)
-    return [rec.data[i+offset] for i in 1:seqlen]
+    return [reinterpret(Int8, rec.data[i+offset]) for i in 1:seqlen]
 end
 
 function Base.getindex(rec::BAMRecord, tag::AbstractString)

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1179,6 +1179,8 @@ end
             CCTAGCCCTAACCCTAACCCTAACCCTAGCCTAAGCCTAAGCCTAAGCCT
             AAGCCTAAGCCTAAGCCTAAGCCTAAGCCTAAGCCTAAGCCTAAGCCTAA
             """
+            @test eltype(qualities(rec)) == Int8
+            @test qualities(rec) == [Int(x) - 33 for x in "#############################@B?8B?BA@@DDBCDDCBC@CDCDCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"]
             @test flag(rec) == 16
             @test cigar(rec) == "27M1D73M"
             @test alignment(rec) == Alignment([


### PR DESCRIPTION
This makes `qualities(::BAMRecord)` return `Vector{Int8}` rather `Vector{UInt8}`. This will improve interoperations between FASTQ and BAM. Also, I believe 127 (= `typemax(Int8)`) is large enough to cover the range of Phred scores.