### PR TITLE
add docs on HTS tools

### DIFF
--- a/docs/src/man/reading.md
+++ b/docs/src/man/reading.md
@@ -108,6 +108,8 @@ The following table summarizes supported file formats.
 | BED         | `BED`    | `Bio.Intervals` | <https://genome.ucsc.edu/FAQ/FAQformat.html#format1>                        |
 | bigBed      | `BigBed` | `Bio.Intervals` | <https://doi.org/10.1093/bioinformatics/btq351>                             |
 | PDB         | `PDB`    | `Bio.Structure` | <http://www.wwpdb.org/documentation/file-format-content/format33/v3.3.html> |
+| SAM         | `SAM`    | `Bio.Align`     | <https://samtools.github.io/hts-specs/SAMv1.pdf>                            |
+| BAM         | `BAM`    | `Bio.Align`     | <https://samtools.github.io/hts-specs/SAMv1.pdf>                            |
 
 
 ### FASTA
@@ -250,3 +252,36 @@ regions.
 PDB is a text-based file format for representing 3D macromolecular structures.
 This has different reader interfaces from other file formats. Please consult the
 [Bio.Structure](structure/) chapter for details.
+
+
+### SAM
+
+* Reader type: `SAMReader`
+* Writer type: `SAMWriter{T<:IO}`
+* Element type: `SAMRecord`
+
+SAM is a text-based file format for representing sequence alignments.
+
+```@docs
+Bio.Align.SAMReader
+Bio.Align.SAMWriter
+```
+
+
+### BAM
+
+* Reader type: `BAMReader`
+* Writer type: `BAMWriter`
+* Element type: `BAMRecord`
+
+BAM is a binary counterpart of the SAM file format.
+
+When writing data in the BAM file format, the underlying output stream needs to
+be wrapped with a `BGZFStream` object provided from
+[BGZFStreams.jl](https://github.com/BioJulia/BGZFStreams.jl).
+
+```@docs
+Bio.Align.BAMReader
+Bio.Align.BAMWriter
+```
+

--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -1,6 +1,15 @@
 # BAM Reader
 # ==========
 
+"""
+    BAMReader(input::IO; index=nothing)
+
+Create a data reader of the BAM file format.
+
+# Arguments
+* `input`: data source
+* `index=nothing`: filepath to a random access index (currently *bai* is Supported)
+"""
 type BAMReader <: Bio.IO.AbstractReader
     stream::BGZFStream
     header::SAMHeader

--- a/src/align/hts/bam/writer.jl
+++ b/src/align/hts/bam/writer.jl
@@ -1,6 +1,15 @@
 # BAM Writer
 # ==========
 
+"""
+    BAMWriter(output::BGZFStream, header::SAMHeader)
+
+Create a data writer of the BAM file format.
+
+# Arguments
+* `output`: data sink
+* `header`: SAM header object
+"""
 type BAMWriter <: Bio.IO.AbstractWriter
     stream::BGZFStream
 end

--- a/src/align/hts/sam/reader.jl
+++ b/src/align/hts/sam/reader.jl
@@ -1,6 +1,14 @@
 # SAM Reader
 # ==========
 
+"""
+    SAMReader(input::IO)
+
+Create a data reader of the SAM file format.
+
+# Arguments
+* `input`: data source
+"""
 type SAMReader <: Bio.IO.AbstractReader
     state::Ragel.State
     header::SAMHeader

--- a/src/align/hts/sam/writer.jl
+++ b/src/align/hts/sam/writer.jl
@@ -1,12 +1,27 @@
 # SAM Writer
 # ==========
 
+"""
+    SAMWriter(output::IO, header::SAMHeader=SAMHeader())
+
+Create a data writer of the SAM file format.
+
+# Arguments
+* `output`: data sink
+* `header=SAMHeader()`: SAM header object
+"""
 type SAMWriter{T<:IO} <: Bio.IO.AbstractWriter
     stream::T
 end
 
 function Bio.IO.stream(writer::SAMWriter)
     return writer.stream
+end
+
+function SAMWriter(output::IO, header::SAMHeader=SAMHeader())
+    writer = SAMWriter(output)
+    write(writer, header)
+    return writer
 end
 
 function Base.write(writer::SAMWriter, header::SAMHeader)

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1102,8 +1102,7 @@ end
                 mktemp() do path, io
                     # copy
                     reader = open(SAMReader, filepath)
-                    writer = SAMWriter(io)
-                    write(writer, header(reader))
+                    writer = SAMWriter(io, header(reader))
                     records = SAMRecord[]
                     for rec in reader
                         push!(records, rec)


### PR DESCRIPTION
I added SAM/BAM docs and a new constructor of `SAMReader` that takes a SAM header as its argument as per `BAMWriter`.