### PR TITLE
swap argument order of seq2ref and ref2seq

### DIFF
--- a/src/align/Align.jl
+++ b/src/align/Align.jl
@@ -127,4 +127,6 @@ include("models.jl")
 include("pairwise/pairalign.jl")
 include("hts/hts.jl")
 
+include("deprecated.jl")
+
 end

--- a/src/align/alignedseq.jl
+++ b/src/align/alignedseq.jl
@@ -74,12 +74,12 @@ function IntervalTrees.last(alnseq::AlignedSequence)
     return alnseq.aln.lastref
 end
 
-function seq2ref(i::Integer, alnseq::AlignedSequence)
-    return seq2ref(i, alnseq.aln)
+function seq2ref(alnseq::AlignedSequence, i::Integer)
+    return seq2ref(alnseq.aln, i)
 end
 
-function ref2seq(i::Integer, alnseq::AlignedSequence)
-    return ref2seq(i, alnseq.aln)
+function ref2seq(alnseq::AlignedSequence, i::Integer)
+    return ref2seq(alnseq.aln, i)
 end
 
 # simple letters and dashes representation of an alignment

--- a/src/align/alignment.jl
+++ b/src/align/alignment.jl
@@ -84,11 +84,11 @@ function Base.show(io::IO, aln::Alignment)
 end
 
 """
-    seq2ref(i, aln)
+    seq2ref(aln, i)
 
 Map a position from sequence to reference.
 """
-function seq2ref(i::Integer, aln::Alignment)
+function seq2ref(aln::Alignment, i::Integer)
     idx = findanchor(aln, i, Val{true})
     if idx == 0
         throw(ArgumentError("invalid sequence position: $i"))
@@ -102,11 +102,11 @@ function seq2ref(i::Integer, aln::Alignment)
 end
 
 """
-    ref2seq(i, aln)
+    ref2seq(aln, i)
 
 Map a position from reference to sequence.
 """
-function ref2seq(i::Integer, aln::Alignment)
+function ref2seq(aln::Alignment, i::Integer)
     idx = findanchor(aln, i, Val{false})
     if idx == 0
         throw(ArgumentError("invalid reference position: $i"))

--- a/src/align/deprecated.jl
+++ b/src/align/deprecated.jl
@@ -1,0 +1,6 @@
+@deprecate seq2ref(i::Integer, aln::Alignment) seq2ref(aln::Alignment, i::Integer)
+@deprecate ref2seq(i::Integer, aln::Alignment) ref2seq(aln::Alignment, i::Integer)
+@deprecate seq2ref(i::Integer, alnseq::AlignedSequence) seq2ref(aln::AlignedSequence, i::Integer)
+@deprecate ref2seq(i::Integer, alnseq::AlignedSequence) ref2seq(aln::AlignedSequence, i::Integer)
+@deprecate seq2ref(i::Integer, aln::PairwiseAlignment) seq2ref(aln::PairwiseAlignment, i::Integer)
+@deprecate ref2seq(i::Integer, aln::PairwiseAlignment) ref2seq(aln::PairwiseAlignment, i::Integer)

--- a/src/align/pairwise/alignment.jl
+++ b/src/align/pairwise/alignment.jl
@@ -128,12 +128,12 @@ function count_aligned(aln::PairwiseAlignment)
     return n
 end
 
-function ref2seq(i::Integer, aln::PairwiseAlignment)
-    return ref2seq(i, aln.a)
+function ref2seq(aln::PairwiseAlignment, i::Integer)
+    return ref2seq(aln.a, i)
 end
 
-function seq2ref(i::Integer, aln::PairwiseAlignment)
-    return seq2ref(i, aln.a)
+function seq2ref(aln::PairwiseAlignment, i::Integer)
+    return seq2ref(aln.a, i)
 end
 
 

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -193,16 +193,16 @@ end
         @test Bio.Align.last(alnseq)  == 27
         # OP_MATCH
         for (seqpos, refpos) in [(1, 5), (2, 6), (4, 8), (13, 18), (19, 27)]
-            @test seq2ref(seqpos, alnseq) == (refpos, OP_MATCH)
-            @test ref2seq(refpos, alnseq) == (seqpos, OP_MATCH)
+            @test seq2ref(alnseq, seqpos) == (refpos, OP_MATCH)
+            @test ref2seq(alnseq, refpos) == (seqpos, OP_MATCH)
         end
         # OP_INSERT
-        @test seq2ref(10, alnseq) == (17, OP_INSERT)
-        @test seq2ref(11, alnseq) == (17, OP_INSERT)
+        @test seq2ref(alnseq, 10) == (17, OP_INSERT)
+        @test seq2ref(alnseq, 11) == (17, OP_INSERT)
         # OP_DELETE
-        @test ref2seq( 9, alnseq) == ( 4, OP_DELETE)
-        @test ref2seq(10, alnseq) == ( 4, OP_DELETE)
-        @test ref2seq(23, alnseq) == (15, OP_DELETE)
+        @test ref2seq(alnseq,  9) == ( 4, OP_DELETE)
+        @test ref2seq(alnseq, 10) == ( 4, OP_DELETE)
+        @test ref2seq(alnseq, 23) == (15, OP_DELETE)
 
         seq = dna"ACGG--TGAAAGGT"
         ref = dna"-CGGGGA----TTT"
@@ -479,12 +479,12 @@ end
         @test isa(result, PairwiseAlignmentResult)
         aln = alignment(result)
         @test isa(aln, PairwiseAlignment)
-        @test seq2ref(1, aln) == (1, OP_SEQ_MATCH)
-        @test seq2ref(2, aln) == (3, OP_SEQ_MATCH)
-        @test seq2ref(3, aln) == (4, OP_SEQ_MATCH)
-        @test ref2seq(1, aln) == (1, OP_SEQ_MATCH)
-        @test ref2seq(2, aln) == (1, OP_DELETE)
-        @test ref2seq(3, aln) == (2, OP_SEQ_MATCH)
+        @test seq2ref(aln, 1) == (1, OP_SEQ_MATCH)
+        @test seq2ref(aln, 2) == (3, OP_SEQ_MATCH)
+        @test seq2ref(aln, 3) == (4, OP_SEQ_MATCH)
+        @test ref2seq(aln, 1) == (1, OP_SEQ_MATCH)
+        @test ref2seq(aln, 2) == (1, OP_DELETE)
+        @test ref2seq(aln, 3) == (2, OP_SEQ_MATCH)
     end
 
     @testset "GlobalAlignment" begin


### PR DESCRIPTION
I don't remember why I decided this argument order, but now it looks a little bit strange to me. Generally, the container argument should come first if possible.