### PR TITLE
fix ismapped

### DIFF
--- a/src/align/hts/bam/record.jl
+++ b/src/align/hts/bam/record.jl
@@ -24,7 +24,7 @@ type BAMRecord
 end
 
 function BAMRecord()
-    return BAMRecord(-1, -1, 0, 0, 0, -1, -1, 0, UInt8[], 0, String[])
+    return BAMRecord(-1, -1, 0, UInt32(SAM_FLAG_UNMAP) << 16, 0, -1, -1, 0, UInt8[], 0, String[])
 end
 
 # NOTE: this does not copy `refseqnames`.
@@ -89,7 +89,7 @@ const BAM_FIXED_FIELDS_BYTES = 32
 Return `true` if and only if `rec` is mapped to a reference sequence.
 """
 function ismapped(rec::BAMRecord)
-    return rec.pos != -1
+    return flag(rec) & SAM_FLAG_UNMAP == 0
 end
 
 """

--- a/src/align/hts/sam/record.jl
+++ b/src/align/hts/sam/record.jl
@@ -17,7 +17,7 @@ type SAMRecord
 end
 
 function SAMRecord()
-    return SAMRecord("*", 0x0000, "*", 0, 0, "*", "*", 0, 0, "*", "*", Dict())
+    return SAMRecord("*", SAM_FLAG_UNMAP, "*", 0, 0, "*", "*", 0, 0, "*", "*", Dict())
 end
 
 function Base.isless(rec1::SAMRecord, rec2::SAMRecord)
@@ -78,7 +78,7 @@ function Base.copy(rec::SAMRecord)
 end
 
 function ismapped(rec::SAMRecord)
-    return rec.pos != 0
+    return flag(rec) & SAM_FLAG_UNMAP == 0
 end
 
 function Bio.Seq.seqname(rec::SAMRecord)

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1023,9 +1023,10 @@ end
         @testset "Record" begin
             rec = SAMRecord()
             @test !ismapped(rec)
+
             # default values
             @test seqname(rec) == "*"
-            @test flag(rec) == 0x0000
+            @test flag(rec) == SAM_FLAG_UNMAP
             @test refname(rec) == "*"
             @test leftposition(rec) == 0
             @test rightposition(rec) == -1
@@ -1064,6 +1065,7 @@ end
             # first record
             rec = SAMRecord()
             read!(reader, rec)
+            @test ismapped(rec)
             @test refname(rec) == "CHROMOSOME_I"
             @test leftposition(rec) == 2
             @test rightposition(rec) == 102
@@ -1134,7 +1136,7 @@ end
             @test leftposition(rec) == 0
             @test rightposition(rec) == -1
             @test mappingquality(rec) == 0
-            @test flag(rec) == 0
+            @test flag(rec) == SAM_FLAG_UNMAP
             @test nextrefname(rec) == "*"
             @test nextrefindex(rec) == 0
             @test nextleftposition(rec) == 0
@@ -1172,6 +1174,7 @@ end
             # first record
             rec = BAMRecord()
             read!(reader, rec)
+            @test ismapped(rec)
             @test refname(rec) == "CHROMOSOME_I"
             @test refindex(rec) == 1
             @test leftposition(rec) == 2


### PR DESCRIPTION
This fixes the implementation of `ismapped` according to the specs of the SAM/BAM file format:
> Bit 0x4 is the only reliable place to tell whether the read is unmapped.