### PR TITLE
bump BGZFStreams dependency

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.5-
-BGZFStreams
+BGZFStreams 0.1
 BufferedStreams 0.2
 Colors
 Distributions

--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -106,7 +106,7 @@ function init_bam_reader(input::IO)
     reader = BAMReader(
         stream,
         samheader,
-        virtualoffset(stream),
+        isa(input, Pipe) ? VirtualOffset(0, 0) : virtualoffset(stream),
         refseqnames,
         refseqlens,
         Nullable())


### PR DESCRIPTION
This makes it possible to read a CRAM file via samtools as follows:

```julia
reader = BAMReader(open(`samtools view -u data.cram`)[1])
```

It may be worth adding `CRAMReader` to Bio.jl that wraps this idiom.