### PR TITLE
simplify the show method of SAM/BAMReader (and fix a bug)

### DIFF
--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -42,12 +42,8 @@ end
 
 function Base.show(io::IO, reader::BAMReader)
     println(io, summary(reader), ":")
-    println("  header: ", reader.header)
-      print("  reference sequences:")
-    for (i, (name, len)) in enumerate(zip(reader.refseqnames, reader.refseqlens))
-        println(io)
-        print("    [", lpad(i, 2), "]: ", name, " (length: ", len, ")")
-    end
+    println(io, "  header keys: ", join(keys(reader.header), ", "))
+      print(io, "  number of contigs: ", length(reader.refseqnames))
 end
 
 function header(reader::BAMReader, fillSQ::Bool=false)

--- a/src/align/hts/sam/reader.jl
+++ b/src/align/hts/sam/reader.jl
@@ -31,6 +31,11 @@ function Bio.IO.stream(reader::SAMReader)
     return reader.state.stream
 end
 
+function Base.show(io::IO, reader::SAMReader)
+    println(io, summary(reader), ":")
+      print(io, "  header keys: ", join(keys(reader.header), ", "))
+end
+
 function header(reader::SAMReader)
     return reader.header
 end

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1057,6 +1057,7 @@ end
             reader = open(SAMReader, joinpath(samdir, "ce#1.sam"))
             @test isa(reader, SAMReader)
             @test eltype(reader) === SAMRecord
+            @test startswith(repr(reader), "Bio.Align.SAMReader:")
 
             # header
             h = header(reader)
@@ -1165,6 +1166,7 @@ end
             reader = open(BAMReader, joinpath(bamdir, "ce#1.bam"))
             @test isa(reader, BAMReader)
             @test eltype(reader) === BAMRecord
+            @test startswith(repr(reader), "Bio.Align.BAMReader:")
 
             # header
             h = header(reader)


### PR DESCRIPTION
This simplifies the `Base.show` method for `SAM/BAMReader` because printing all contig names often fills a terminal window.