### PR TITLE
make BAMReader type-stable

### DIFF
--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -32,7 +32,7 @@ function BAMReader(input::IO; index=nothing)
     return reader
 end
 
-function Base.eltype(::Type{BAMReader})
+function Base.eltype{T}(::Type{BAMReader{T}})
     return BAMRecord
 end
 

--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -10,8 +10,8 @@ Create a data reader of the BAM file format.
 * `input`: data source
 * `index=nothing`: filepath to a random access index (currently *bai* is Supported)
 """
-type BAMReader <: Bio.IO.AbstractReader
-    stream::BGZFStream
+type BAMReader{T} <: Bio.IO.AbstractReader
+    stream::BGZFStream{T}
     header::SAMHeader
     start_offset::VirtualOffset
     refseqnames::Vector{String}
@@ -105,7 +105,7 @@ function init_bam_reader(input::IO)
         isa(input, Pipe) ? VirtualOffset(0, 0) : virtualoffset(stream),
         refseqnames,
         refseqlens,
-        Nullable())
+        Nullable{BAI}())
 
     return reader
 end

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1182,7 +1182,7 @@ end
             reader = open(BAMReader, joinpath(bamdir, "ce#1.bam"))
             @test isa(reader, BAMReader)
             @test eltype(reader) === BAMRecord
-            @test startswith(repr(reader), "Bio.Align.BAMReader:")
+            @test startswith(repr(reader), "Bio.Align.BAMReader{IOStream}:")
 
             # header
             h = header(reader)


### PR DESCRIPTION
This simple patch significantly (~15%) improves the performance of reading BAM records.

```julia
using Bio.Align

let
    reader = open(BAMReader, "GSE25840_GSM424320_GM06985_gencode_spliced.bam")
    record = BAMRecord()
    @time while !eof(reader)
        read!(reader, record)
    end
    close(reader)
end

#=
~/.j/v/Bio (master|…) $ julia5 test.jl
 15.774832 seconds (63.40 M allocations: 977.437 MB, 1.33% gc time)
~/.j/v/Bio (master|✚1…) $ julia5 test.jl
 13.658773 seconds (22.08 M allocations: 346.885 MB, 1.59% gc time)
=#
```