### PR TITLE
clean up SAM/BAMRecord printing

### DIFF
--- a/src/align/hts/bam/record.jl
+++ b/src/align/hts/bam/record.jl
@@ -64,22 +64,6 @@ function Base.:(==)(rec1::BAMRecord, rec2::BAMRecord)
         rec1.tlen       == rec2.tlen)  # TODO: check data
 end
 
-function Base.show(io::IO, rec::BAMRecord)
-    println(io, summary(rec), ':')
-    println(io, "  reference name: ", refname(rec))
-    println(io, "  leftmost position: ", leftposition(rec))
-    println(io, "  next reference name: ", nextrefname(rec))
-    println(io, "  next leftmost position: ", nextleftposition(rec))
-    println(io, "  mapping quality: ", mappingquality(rec))
-    println(io, "  flag: ", flag(rec))
-    println(io, "  template length: ", templatelength(rec))
-    println(io, "  sequence name: ", seqname(rec))
-    println(io, "  CIGAR string: ", cigar(rec))
-    println(io, "  sequence: ", String(sequence(rec)))
-    println(io, "  base qualities: ", qualities(rec))
-      print(io, "  optional fields: ", optinal_fields(rec))
-end
-
 # the data size of fixed-length fields (.refid-.tlen)
 const BAM_FIXED_FIELDS_BYTES = 32
 
@@ -294,7 +278,7 @@ function Base.haskey(rec::BAMRecord, tag::AbstractString)
     return findtag(rec.data, auxdata_position(rec), UInt8(tag[1]), UInt8(tag[2])) > 0
 end
 
-function optinal_fields(rec::BAMRecord)
+function optional_fields(rec::BAMRecord)
     return AuxDataDict(rec.data[auxdata_position(rec):rec.datasize])
 end
 

--- a/src/align/hts/hts.jl
+++ b/src/align/hts/hts.jl
@@ -14,3 +14,32 @@ import BufferedStreams: BufferedInputStream
 
 include("sam/sam.jl")
 include("bam/bam.jl")
+
+function Base.show(io::IO, rec::Union{SAMRecord,BAMRecord})
+    name = seqname(rec)
+    if isempty(name)
+        name = "(empty name)"
+    end
+    if get(io, :compact, false)
+        if ismapped(rec)
+            range = string(refname(rec), ':', leftposition(rec), '-', rightposition(rec))
+            print(io, name, "\t$(range)\t", cigar(rec))
+        else
+            print(io, name, "\tunmapped")
+        end
+    else
+        println(io, summary(rec), ':')
+        println(io, "  sequence name: ", name)
+        println(io, "  reference name: ", refname(rec))
+        println(io, "  leftmost position: ", leftposition(rec))
+        println(io, "  next reference name: ", nextrefname(rec))
+        println(io, "  next leftmost position: ", nextleftposition(rec))
+        println(io, "  mapping quality: ", mappingquality(rec))
+        println(io, "  flag: ", flag(rec))
+        println(io, "  template length: ", templatelength(rec))
+        println(io, "  CIGAR string: ", cigar(rec))
+        println(io, "  sequence: ", String(sequence(rec)))
+        println(io, "  base qualities: ", qualities(rec))
+          print(io, "  optional fields: ", optional_fields(rec))
+    end
+end

--- a/src/align/hts/sam/record.jl
+++ b/src/align/hts/sam/record.jl
@@ -45,22 +45,6 @@ function Base.:(==)(rec1::SAMRecord, rec2::SAMRecord)
         rec1.optional_fields == rec2.optional_fields)
 end
 
-function Base.show(io::IO, rec::SAMRecord)
-    println(io, summary(rec), ':')
-    println(io, "  reference name: ", refname(rec))
-    println(io, "  leftmost position: ", leftposition(rec))
-    println(io, "  next reference name: ", nextrefname(rec))
-    println(io, "  next leftmost position: ", nextleftposition(rec))
-    println(io, "  mapping quality: ", mappingquality(rec))
-    println(io, "  flag: ", flag(rec))
-    println(io, "  template length: ", templatelength(rec))
-    println(io, "  sequence name: ", seqname(rec))
-    println(io, "  CIGAR string: ", cigar(rec))
-    println(io, "  sequence: ", sequence(rec))
-    println(io, "  base qualities: ", qualities(rec))
-      print(io, "  optional fields: ", rec.optional_fields)
-end
-
 function Base.copy(rec::SAMRecord)
     return SAMRecord(
         copy(rec.name),
@@ -157,6 +141,10 @@ end
 function Base.haskey(rec::SAMRecord, tag::AbstractString)
     checkkeytag(tag)
     return haskey(rec.optional_fields, tag)
+end
+
+function optional_fields(rec::SAMRecord)
+    return rec.optional_fields
 end
 
 # Return the length of alignment.

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1039,6 +1039,14 @@ end
             @test qualities(rec) == "*"
             @test Align.alignment_length(rec) === 0
 
+            buf = IOBuffer()
+            show(buf, rec)
+            @test startswith(takebuf_string(buf), "Bio.Align.SAMRecord:")
+
+            buf = IOBuffer()
+            showcompact(buf, rec)
+            @test takebuf_string(buf) == "*\tunmapped"
+
             # set & delete tags
             rec = SAMRecord()
             @test !haskey(rec, "MN")
@@ -1146,6 +1154,14 @@ end
             @test alignment(rec) == Alignment(AlignmentAnchor[])
             @test qualities(rec) == UInt8[]
             @test Align.alignment_length(rec) === 0
+
+            buf = IOBuffer()
+            show(buf, rec)
+            @test startswith(takebuf_string(buf), "Bio.Align.BAMRecord:")
+
+            buf = IOBuffer()
+            showcompact(buf, rec)
+            @test takebuf_string(buf) == "(empty name)\tunmapped"
 
             # set & delete tags
             rec = BAMRecord()


### PR DESCRIPTION
This unifies the show methods for SAM and BAM records and implements a single line printer.