### PR TITLE
do not check ismapped when checking isoverlapping

### DIFF
--- a/src/align/hts/bam/intersect.jl
+++ b/src/align/hts/bam/intersect.jl
@@ -46,9 +46,11 @@ function advance!(iter, rec, i)
     return i, rec
 end
 
-function Bio.Intervals.isoverlapping(rec, refindex_, interval)
-    return ismapped(rec) &&
-        refindex(rec) == refindex_ &&
+function Bio.Intervals.isoverlapping(
+        rec::BAMRecord,
+        refindex_::Integer,
+        interval::UnitRange)
+    return refindex(rec) == refindex_ &&
         leftposition(rec) ≤ last(interval) &&
         rightposition(rec) ≥ first(interval)
 end


### PR DESCRIPTION
An unmapped record may have mapped position of its mate read. This fixes the
behavior of `isoverlapping` so that a record does not need to be mapped to
overlap a genomic range as per samtools view.