### PR TITLE
re-organize BAMRecord fields

### DIFF
--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -111,13 +111,15 @@ function init_bam_reader(input::IO)
 end
 
 function Base.read!(reader::BAMReader, record::BAMRecord)
-    datasize = read(reader.stream, Int32) - BAM_FIXED_FIELDS_BYTES
-    unsafe_read(reader.stream, pointer_from_objref(record), BAM_FIXED_FIELDS_BYTES)
-    if length(record.data) < datasize
-        resize!(record.data, datasize)
+    unsafe_read(
+        reader.stream,
+        pointer_from_objref(record),
+        BAM_FIXED_FIELDS_BYTES)
+    dsize = data_size(record)
+    if length(record.data) < dsize
+        resize!(record.data, dsize)
     end
-    unsafe_read(reader.stream, pointer(record.data), datasize)
-    record.datasize = datasize
+    unsafe_read(reader.stream, pointer(record.data), dsize)
     record.refseqnames = reader.refseqnames
     return record
 end

--- a/src/align/hts/bam/writer.jl
+++ b/src/align/hts/bam/writer.jl
@@ -61,8 +61,7 @@ end
 
 function Base.write(writer::BAMWriter, record::BAMRecord)
     n = 0
-    n += write(writer.stream, Int32(BAM_FIXED_FIELDS_BYTES + record.datasize))
     n += unsafe_write(writer.stream, pointer_from_objref(record), BAM_FIXED_FIELDS_BYTES)
-    n += unsafe_write(writer.stream, pointer(record.data), record.datasize)
+    n += unsafe_write(writer.stream, pointer(record.data), data_size(record))
     return n
 end


### PR DESCRIPTION
This change reduces the number of read/writer operations when reading/writing BAM
records from a file, which improves the performance of BAM I/O.

```julia
using Bio.Align

let
    reader = open(BAMReader, "GSE25840_GSM424320_GM06985_gencode_spliced.bam")
    record = BAMRecord()
    @time while !eof(reader)
        read!(reader, record)
    end
    close(reader)
end

#=
~/.j/v/Bio (master|…) $ julia5 test.jl
 13.365396 seconds (22.08 M allocations: 346.885 MB, 0.15% gc time)
~/.j/v/Bio (master|…) $ julia5 test.jl
 13.287189 seconds (22.08 M allocations: 346.885 MB, 0.15% gc time)
v.s.
~/.j/v/Bio (reorg-bamrecord|…) $ julia5 test.jl
 12.702789 seconds (1.42 M allocations: 31.639 MB, 0.04% gc time)
~/.j/v/Bio (reorg-bamrecord|…) $ julia5 test.jl
 12.796799 seconds (1.42 M allocations: 31.639 MB, 0.05% gc time)
=#
```