### PR TITLE
Sliding window distance computation

### DIFF
--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -40,6 +40,17 @@ immutable EachWindowIterator{T <: ArrayOrStringOrSeq}
 end
 
 
+immutable EachWindow
+    to::Int
+    width::Int
+    step::Int
+end
+
+function Base.size(winitr::EachWindow)
+    return length(StepRange(winitr.width+1, winitr.step, length(winitr.data)))
+end
+
+
 """
 Calculate the number of windows that will result from iterating across the container.
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -244,7 +244,7 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, 
     counts, wsizes, ranges = distance(Count{T}, seqs, width, step)
     res = Matrix{Float64}(size(counts))
     @inbounds for i in 1:endof(counts)
-        res[i] = expected_distance(Proportion{T}, counts[i] / wsizes[i])
+        res[i] = expected_distance(Proportion{T}, counts[i], wsizes[i])
     end
     return res, wsizes, ranges
 end

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -337,7 +337,7 @@ function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{Bio
     a, b = size(ps)
     est = Matrix{Float64}(a, b)
     var = Matrix{Float64}(a, b)
-    @inbounds for i in 1:endof(counts)
+    @inbounds for i in 1:endof(ps)
         p = ps[i]
         l = wsizes[i]
         est[i] = expected_distance(JukesCantor69, p)

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -140,6 +140,8 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
     nwindows = length(ends)
     mcounts = Matrix{Int}(nwindows, npairs)
     acounts = Matrix{Int}(nwindows, npairs)
+    fill!(mcounts, 0)
+    fill!(acounts, 0)
     ranges = Vector{Pair{Int,Int}}(nwindows)
 
     @inbounds for pair in 1:npairs

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -148,13 +148,13 @@ counted by the function for each window.
 function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     mutation_flags, ambiguous_flags = flagmutations(T, seqs)
     nbases, npairs = size(mutation_flags)
-    if width >= 1
+    if width < 1
         throw(ArgumentError("`window` width must be ≥ 1."))
     end
-    if step >= 1
+    if step < 1
         throw(ArgumentError("`step` must be ≥ 1."))
     end
-    if width <= nbases
+    if width > nbases
         throw(ArgumentError("The `window` size cannot be greater than number of data elements."))
     end
     starts = 1:step:nbases
@@ -189,13 +189,13 @@ end
 function distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     transitionFlags, transversionFlags, ambiguous_flags = flagmutations(TransitionMutation, TransversionMutation, seqs)
     nbases, npairs = size(transitionFlags)
-    if width >= 1
+    if width < 1
         throw(ArgumentError("`window` width must be ≥ 1."))
     end
-    if step >= 1
+    if step < 1
         throw(ArgumentError("`step` must be ≥ 1."))
     end
-    if width <= nbases
+    if width > nbases
         throw(ArgumentError("The `window` size cannot be greater than number of data elements."))
     end
     starts = 1:step:nbases

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -327,6 +327,20 @@ function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSeque
     return D, V
 end
 
+function distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{T}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+    ps, wsizes, ranges = distance(Count{Kimura80}, seqs, width, step)
+    a, b = size(ps)
+    est = Matrix{Float64}(a, b)
+    var = Matrix{Float64}(a, b)
+    @inbounds for i in 1:endof(counts)
+        p = ps[i]
+        l = esizes[i]
+        est[i] = expected_distance(JukesCantor69, p)
+        var[i] = variance(JukesCantor69, p, l)
+    end
+    return est, var, ranges
+end
+
 """
     distance{N<:Nucleotide}(::Type{Kimura80}, seqs::Matrix{N})
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -133,6 +133,18 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
     return count_mutations(T, seqs)
 end
 
+"""
+    distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+
+A distance method which computes pairwise distances using a sliding window.
+
+As the window of `width` base pairs in size moves across a pair of sequences it
+computes the distance between the two sequences in that window.
+
+This method computes mutation counts for every window, and returns a tuple of the
+matrix of p-distances for every window, a matrix of the number of valid sites
+counted by the function for each window.
+"""
 function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     mutationFlags, ambiguousFlags = flagmutations(T, seqs)
     nbases, npairs = size(mutationFlags)
@@ -308,6 +320,18 @@ function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{Bio
     return D, V
 end
 
+"""
+    distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+
+A distance method which computes pairwise distances using a sliding window.
+
+As the window of `width` base pairs in size moves across a pair of sequences it
+computes the distance between the two sequences in that window.
+
+This method computes the JukesCantor69 distance for every window, and returns a tuple of the
+matrix of p-distances for every window, a matrix of the number of valid sites
+counted by the function for each window.
+"""
 function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     ps, wsizes, ranges = distance(Proportion{AnyMutation}, seqs, width, step)
     a, b = size(ps)
@@ -366,6 +390,18 @@ function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSeque
     return D, V
 end
 
+"""
+    distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+
+A distance method which computes pairwise distances using a sliding window.
+
+As the window of `width` base pairs in size moves across a pair of sequences it
+computes the distance between the two sequences in that window.
+
+This method computes the Kimura80 distance for every window, and returns a tuple of the
+matrix of p-distances for every window, a matrix of the number of valid sites
+counted by the function for each window.
+"""
 function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     tss, tvs, wsizes, ranges = distance(Count{Kimura80}, seqs, width, step)
     a, b = size(tss)

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -315,7 +315,7 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{JukesCantor69}, 
     var = Matrix{Float64}(a, b)
     @inbounds for i in 1:endof(counts)
         p = ps[i]
-        l = esizes[i]
+        l = wsizes[i]
         est[i] = expected_distance(JukesCantor69, p)
         var[i] = variance(JukesCantor69, p, l)
     end
@@ -367,15 +367,20 @@ function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSeque
 end
 
 function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
-    ps, wsizes, ranges = distance(Count{Kimura80}, seqs, width, step)
-    a, b = size(ps)
+    tss, tvs, wsizes, ranges = distance(Count{Kimura80}, seqs, width, step)
+    a, b = size(tss)
     est = Matrix{Float64}(a, b)
     var = Matrix{Float64}(a, b)
     @inbounds for i in 1:endof(counts)
-        p = ps[i]
-        l = esizes[i]
-        est[i] = expected_distance(JukesCantor69, p)
-        var[i] = variance(JukesCantor69, p, l)
+        L = l[i]
+        P = tss[i] / L
+        Q = tvs[i] / L
+        a1 = 1 - 2 * P - Q
+        a2 = 1 - 2 * Q
+        tv = tvs[i]
+        l = wsizes[i]
+        est[i] = expected_distance(Kimura80, a1, a2)
+        var[i] = variance(Kimura80, P, Q, L, a1, a2)
     end
     return est, var, ranges
 end

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -146,9 +146,9 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
 
     @inbounds for pair in 1:npairs
         for i in 1:nwindows
-            for j in starts[i]:ends[i]
-                mcounts[i, pair] += mutationFlags[(pair - 1) * nbases + j]
-                acounts[i, pair] += ambiguousFlags[(pair - 1) * nbases + j]
+            @simd for j in starts[i]:ends[i]
+                mcounts[(pair - 1) * nwindows + i] += mutationFlags[(pair - 1) * nbases + j]
+                acounts[(pair - 1) * nwindows + i] += ambiguousFlags[(pair - 1) * nbases + j]
             end
             ranges[i] = Pair(starts[i],ends[i])
         end

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -146,11 +146,17 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
 
     @inbounds for pair in 1:npairs
         for i in 1:nwindows
-            @simd for j in starts[i]:ends[i]
-                mcounts[(pair - 1) * nwindows + i] += mutationFlags[(pair - 1) * nbases + j]
-                acounts[(pair - 1) * nwindows + i] += ambiguousFlags[(pair - 1) * nbases + j]
+            from = starts[i]
+            to = ends[i]
+            mcount = 0
+            acount = 0
+            @simd for j in from:to
+                mcount += mutationFlags[(pair - 1) * nbases + j]
+                acount += ambiguousFlags[(pair - 1) * nbases + j]
             end
             ranges[i] = Pair(starts[i],ends[i])
+            mcounts[(pair - 1) * nwindows + i] = mcount
+            acounts[(pair - 1) * nwindows + i] = acount
         end
     end
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -136,7 +136,7 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
     @assert step >= 1 "step must be ≥ 1."
     @assert width <= nbases "The window size cannot be greater than number of data elements."
     starts = 1:step:nbases
-    ends = width+1:step:nbases
+    ends = width:step:nbases
     nwindows = length(ends)
     mcounts = Matrix{Int}(nwindows, npairs)
     acounts = Matrix{Int}(nwindows, npairs)

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -269,6 +269,20 @@ function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{Bio
     return D, V
 end
 
+function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+    ps, wsizes, ranges = distance(Proportion{AnyMutation}, seqs, width, step)
+    a, b = size(ps)
+    est = Matrix{Float64}(a, b)
+    var = Matrix{Float64}(a, b)
+    @inbounds for i in 1:endof(counts)
+        p = ps[i]
+        l = esizes[i]
+        est[i] = expected_distance(JukesCantor69, p)
+        var[i] = variance(JukesCantor69, p, l)
+    end
+    return est, var, ranges
+end
+
 """
     distance{N<:Nucleotide}(::Type{JukesCantor69}, seqs::Matrix{N})
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -308,7 +308,7 @@ function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{Bio
     return D, V
 end
 
-function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     ps, wsizes, ranges = distance(Proportion{AnyMutation}, seqs, width, step)
     a, b = size(ps)
     est = Matrix{Float64}(a, b)

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -254,7 +254,7 @@ vector of the number of valid (i.e. non-ambiguous sites) counted by the function
 function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}})
     d, l = distance(Count{T}, seqs)
     D = Vector{Float64}(length(d))
-    @inbounds for i in 1:length(D)
+    @inbounds @simd for i in 1:length(D)
         D[i] = d[i] / l[i]
     end
     return D, l

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -134,7 +134,7 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
 end
 
 """
-    distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+    distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
 
 A distance method which computes pairwise distances using a sliding window.
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -145,18 +145,21 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
     ranges = Vector{Pair{Int,Int}}(nwindows)
 
     @inbounds for pair in 1:npairs
+        pairoffset = pair - 1
+        windowoffset = pairoffset * nwindows
+        flagsoffset = pairoffset * nbases
         for i in 1:nwindows
             from = starts[i]
             to = ends[i]
             mcount = 0
             acount = 0
             @simd for j in from:to
-                mcount += mutationFlags[(pair - 1) * nbases + j]
-                acount += ambiguousFlags[(pair - 1) * nbases + j]
+                mcount += mutationFlags[flagsoffset + j]
+                acount += ambiguousFlags[flagsoffset + j]
             end
             ranges[i] = Pair(starts[i],ends[i])
-            mcounts[(pair - 1) * nwindows + i] = mcount
-            acounts[(pair - 1) * nwindows + i] = acount
+            mcounts[windowoffset + i] = mcount
+            acounts[windowoffset + i] = acount
         end
     end
 

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -150,10 +150,11 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
                 mcounts[i, pair] += mutationFlags[(pair - 1) * nbases + j]
                 acounts[i, pair] += ambiguousFlags[(pair - 1) * nbases + j]
             end
+            ranges[i] = Pair(starts[i],ends[i])
         end
     end
 
-    return mcounts, acounts
+    return mcounts, acounts, ranges
 
 end
 

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -196,7 +196,7 @@ function flagmutations{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N}
     return ismutant, isambiguous
 end
 
-function flagmutations{M<:MutationType,N<:NucleotideAlphabet}(::Type{M}, seqs::Vector{BioSequence{A}})
+function flagmutations{M<:MutationType,A<:NucleotideAlphabet}(::Type{M}, seqs::Vector{BioSequence{A}})
     return flagmutations(M, seqmatrix(seqs, :seq))
 end
 

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -292,7 +292,7 @@ function flagmutations{N<:Nucleotide}(::Type{TransitionMutation}, ::Type{Transve
     return istransition, istransversion, isambiguous
 end
 
-function flagmutations{M<:MutationType,A<:NucleotideAlphabet}(::Type{TransitionMutation}, ::Type{TransversionMutation}, seqs::Vector{BioSequence{A}})
+function flagmutations{A<:NucleotideAlphabet}(::Type{TransitionMutation}, ::Type{TransversionMutation}, seqs::Vector{BioSequence{A}})
     return flagmutations(TransitionMutation, TransversionMutation, seqmatrix(seqs, :seq))
 end
 

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -196,8 +196,9 @@ function flagmutations{M<:MutationType,N<:Nucleotide}(::Type{M}, seqs::Matrix{N}
     return ismutant, isambiguous
 end
 
-
-
+function flagmutations{M<:MutationType,N<:NucleotideAlphabet}(::Type{M}, seqs::Vector{BioSequence{A}})
+    return flagmutations(M, seqmatrix(seqs, :seq))
+end
 
 """
     count_mutations{T<:MutationType,N<:Nucleotide}(::Type{T}, seqs::Matrix{N})

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -264,6 +264,40 @@ function count_mutations{T<:MutationType,A<:NucleotideAlphabet}(::Type{T}, seque
     return count_mutations(T, seqs)
 end
 
+
+function flagmutations{N<:Nucleotide}(::Type{TransitionMutation}, ::Type{TransversionMutation}, seqs::Matrix{N})
+    seqsize, nseqs = size(seqs)
+    istransition = Matrix{Bool}(seqsize, binomial(nseqs, 2))
+    istransversion = Matrix{Bool}(seqsize, binomial(nseqs, 2))
+    isambiguous = Matrix{Bool}(seqsize, binomial(nseqs, 2))
+    col = 1
+    @inbounds for i1 in 1:nseqs
+        s1offset = (i1 - 1) * seqsize
+        for i2 in i1+1:nseqs
+            s2offset = (i2 - 1) * seqsize
+            resoffset = (col - 1) * seqsize
+            for s in 1:seqsize
+                s1 = seqs[s1offset + s]
+                s2 = seqs[s2offset + s]
+                isamb = is_ambiguous_strict(s1, s2)
+                isdiff = s1 != s2
+                ists = is_mutation(TransitionMutation, s1, s2)
+                isambiguous[resoffset + s] = isamb
+                istransition[resoffset + s] = !isamb & isdiff & ists
+                istransversion[resoffset + s] = !isamb & isdiff & !ists
+            end
+            col += 1
+        end
+    end
+    return istransition, istransversion, isambiguous
+end
+
+function flagmutations{M<:MutationType,A<:NucleotideAlphabet}(::Type{TransitionMutation}, ::Type{TransversionMutation}, seqs::Vector{BioSequence{A}})
+    return flagmutations(TransitionMutation, TransversionMutation, seqmatrix(seqs, :seq))
+end
+
+
+
 """
     count_mutations{N<:Nucleotide}(::Type{TransitionMutation}, ::Type{TransversionMutation}, sequences::Matrix{N})
 

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -57,12 +57,12 @@ end
     @test distance(Count{TransversionMutation}, m1) == ([8], [16])
     @test distance(Count{Kimura80}, m1) == ([4], [8], [16])
 
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][:,1] == [2; 4; 3; 3]
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][:,1] == [5; 5; 3; 5]
-    @test distance(Count{TransitionMutation}, dnas2)[1][:,1] == [0; 2; 1; 2]
-    @test distance(Count{TransitionMutation}, dnas2)[2][:,1] == [5; 5; 3; 5]
-    @test distance(Count{TransversionMutation}, dnas2)[1][:,1] == [2; 2; 2; 2]
-    @test distance(Count{TransversionMutation}, dnas2)[2][:,1] == [5; 5; 3; 5]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][:] == [2; 4; 3; 3]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][:] == [5; 5; 3; 5]
+    @test distance(Count{TransitionMutation}, dnas2)[1][:] == [0; 2; 1; 2]
+    @test distance(Count{TransitionMutation}, dnas2)[2][:] == [5; 5; 3; 5]
+    @test distance(Count{TransversionMutation}, dnas2)[1][:] == [2; 2; 2; 2]
+    @test distance(Count{TransversionMutation}, dnas2)[2][:] == [5; 5; 3; 5]
     #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -77,19 +77,19 @@ end
     d = distance(Proportion{AnyMutation}, dnas2, 5, 5)
     a = [0.4, 0.8, 1.0, 0.6]
     for i in 1:length(d[1])
-        @test isapprox(d[1][i], a[i])
+        @test_approx_eq_eps d[1][i] a[i] 1e-4
     end
     @test d[2][:] == [5, 5, 3, 5]
     d = distance(Proportion{TransitionMutation}, dnas2, 5, 5)
     a = [0.0, 0.4, 0.333333, 0.2]
     for i in 1:length(d[1])
-        @test isapprox(d[1][i], a[i])
+        @test_approx_eq_eps d[1][i] a[i] 1e-4
     end
     @test d[2][:] == [5, 5, 3, 5]
     d = distance(Proportion{TransversionMutation}, dnas2, 5, 5)
     a = [0.4, 0.4, 0.666667, 0.4]
     for i in 1:length(d[1])
-        @test isapprox(d[1][i], a[i])
+        @test_approx_eq_eps d[1][i] a[i] 1e-4
     end
     @test d[2][:] == [5, 5, 3, 5]
 

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -63,7 +63,7 @@ end
     @test distance(Count{TransitionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
     @test distance(Count{TransversionMutation}, dnas2, 5, 5)[1][:] == [2, 2, 2, 2]
     @test distance(Count{TransversionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
-    #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
+    @test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])
     @test distance(Count{TransitionMutation}, dnas2) == ([4], [18])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -84,11 +84,13 @@ end
     a = [0.0, 0.4, 0.333333, 0.2]
     for i in 1:length(d[1])
         @test isapprox(d[1][i], a[i])
+    end
     @test d[2][:] == [5, 5, 3, 5]
     d = distance(Proportion{TransversionMutation}, dnas2, 5, 5)
     a = [0.4, 0.4, 0.666667, 0.4]
     for i in 1:length(d[1])
         @test isapprox(d[1][i], a[i])
+    end
     @test d[2][:] == [5, 5, 3, 5]
 
     @test distance(Proportion{AnyMutation}, dnas1) == ([(12 / 16)], [16])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -57,12 +57,12 @@ end
     @test distance(Count{TransversionMutation}, m1) == ([8], [16])
     @test distance(Count{Kimura80}, m1) == ([4], [8], [16])
 
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][1:4] == [2, 4, 3, 3]
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
-    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[1][1:4] == [0, 2, 1, 1]
-    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
-    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[1][1:4] == [2, 2, 2, 2]
-    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][:] == [2, 4, 3, 3]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
+    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[1][:] == [0, 2, 1, 1]
+    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
+    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[1][:] == [2, 2, 2, 2]
+    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
     #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])
@@ -73,6 +73,13 @@ end
     @test distance(Count{TransitionMutation}, m2) == ([4], [18])
     @test distance(Count{TransversionMutation}, m2) == ([8], [18])
     @test distance(Count{Kimura80}, m2) == ([4], [8], [18])
+
+    @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.8, 1.0, 0.6]
+    @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
+    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[1][:] == [0.0, 0.4, 0.333, 0.2]
+    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
+    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.4, 0.666, 0.4]
+    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
 
     @test distance(Proportion{AnyMutation}, dnas1) == ([(12 / 16)], [16])
     @test distance(Proportion{TransitionMutation}, dnas1) == ([(4 / 16)], [16])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -57,12 +57,12 @@ end
     @test distance(Count{TransversionMutation}, m1) == ([8], [16])
     @test distance(Count{Kimura80}, m1) == ([4], [8], [16])
 
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][:] == [2; 4; 3; 3]
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][:] == [5; 5; 3; 5]
-    @test distance(Count{TransitionMutation}, dnas2)[1][:] == [0; 2; 1; 2]
-    @test distance(Count{TransitionMutation}, dnas2)[2][:] == [5; 5; 3; 5]
-    @test distance(Count{TransversionMutation}, dnas2)[1][:] == [2; 2; 2; 2]
-    @test distance(Count{TransversionMutation}, dnas2)[2][:] == [5; 5; 3; 5]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][1:4] == [2, 4, 3, 3]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
+    @test distance(Count{TransitionMutation}, dnas2)[1][1:4] == [0, 2, 1, 2]
+    @test distance(Count{TransitionMutation}, dnas2)[2][1:4] == [5, 5, 3, 5]
+    @test distance(Count{TransversionMutation}, dnas2)[1][1:4] == [2, 2, 2, 2]
+    @test distance(Count{TransversionMutation}, dnas2)[2][1:4] == [5, 5, 3, 5]
     #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -57,12 +57,12 @@ end
     @test distance(Count{TransversionMutation}, m1) == ([8], [16])
     @test distance(Count{Kimura80}, m1) == ([4], [8], [16])
 
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1] == [2; 4; 3; 3]
-    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2] == [5; 5; 3; 5]
-    @test distance(Count{TransitionMutation}, dnas2)[1] == [0; 2; 1; 2]
-    @test distance(Count{TransitionMutation}, dnas2)[2] == [5; 5; 3; 5]
-    @test distance(Count{TransversionMutation}, dnas2)[1] == [2; 2; 2; 2]
-    @test distance(Count{TransversionMutation}, dnas2)[2] == [5; 5; 3; 5]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][:,1] == [2; 4; 3; 3]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][:,1] == [5; 5; 3; 5]
+    @test distance(Count{TransitionMutation}, dnas2)[1][:,1] == [0; 2; 1; 2]
+    @test distance(Count{TransitionMutation}, dnas2)[2][:,1] == [5; 5; 3; 5]
+    @test distance(Count{TransversionMutation}, dnas2)[1][:,1] == [2; 2; 2; 2]
+    @test distance(Count{TransversionMutation}, dnas2)[2][:,1] == [5; 5; 3; 5]
     #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -74,12 +74,22 @@ end
     @test distance(Count{TransversionMutation}, m2) == ([8], [18])
     @test distance(Count{Kimura80}, m2) == ([4], [8], [18])
 
-    @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.8, 1.0, 0.6]
-    @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
-    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[1][:] == [0.0, 0.4, 0.333333, 0.2]
-    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
-    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.4, 0.666667, 0.4]
-    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
+    d = distance(Proportion{AnyMutation}, dnas2, 5, 5)
+    a = [0.4, 0.8, 1.0, 0.6]
+    for i in 1:length(d[1])
+        @test isapprox(d[1][i], a[i])
+    end
+    @test d[2][:] == [5, 5, 3, 5]
+    d = distance(Proportion{TransitionMutation}, dnas2, 5, 5)
+    a = [0.0, 0.4, 0.333333, 0.2]
+    for i in 1:length(d[1])
+        @test isapprox(d[1][i], a[i])
+    @test d[2][:] == [5, 5, 3, 5]
+    d = distance(Proportion{TransversionMutation}, dnas2, 5, 5)
+    a = [0.4, 0.4, 0.666667, 0.4]
+    for i in 1:length(d[1])
+        @test isapprox(d[1][i], a[i])
+    @test d[2][:] == [5, 5, 3, 5]
 
     @test distance(Proportion{AnyMutation}, dnas1) == ([(12 / 16)], [16])
     @test distance(Proportion{TransitionMutation}, dnas1) == ([(4 / 16)], [16])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -59,10 +59,10 @@ end
 
     @test distance(Count{AnyMutation}, dnas2, 5, 5)[1][1:4] == [2, 4, 3, 3]
     @test distance(Count{AnyMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
-    @test distance(Count{TransitionMutation}, dnas2)[1][1:4] == [0, 2, 1, 2]
-    @test distance(Count{TransitionMutation}, dnas2)[2][1:4] == [5, 5, 3, 5]
-    @test distance(Count{TransversionMutation}, dnas2)[1][1:4] == [2, 2, 2, 2]
-    @test distance(Count{TransversionMutation}, dnas2)[2][1:4] == [5, 5, 3, 5]
+    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[1][1:4] == [0, 2, 1, 1]
+    @test distance(Count{TransitionMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
+    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[1][1:4] == [2, 2, 2, 2]
+    @test distance(Count{TransversionMutation}, dnas2, 5, 5)[2][1:4] == [5, 5, 3, 5]
     #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -44,7 +44,8 @@ end
     dnas1 = [dna"ATTG-ACCTGGNTTTCCGAA", dna"A-ACAGAGTATACRGTCGTC"]
     m1 = seqmatrix(dnas1, :seq)
 
-    dnas2 = [dna"attgaacctggntttccgaa", dna"atacagagtatacrgtcgtc"]
+    dnas2 = [dna"attgaacctggntttccgaa",
+             dna"atacagagtatacrgtcgtc"]
     m2 = seqmatrix(dnas2, :seq)
 
     @test distance(Count{AnyMutation}, dnas1) == ([12], [16])
@@ -55,6 +56,14 @@ end
     @test distance(Count{TransitionMutation}, m1) == ([4], [16])
     @test distance(Count{TransversionMutation}, m1) == ([8], [16])
     @test distance(Count{Kimura80}, m1) == ([4], [8], [16])
+
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[1] == [2; 4; 3; 3]
+    @test distance(Count{AnyMutation}, dnas2, 5, 5)[2] == [5; 5; 3; 5]
+    @test distance(Count{TransitionMutation}, dnas2)[1] == [0; 2; 1; 2]
+    @test distance(Count{TransitionMutation}, dnas2)[2] == [5; 5; 3; 5]
+    @test distance(Count{TransversionMutation}, dnas2)[1] == [2; 2; 2; 2]
+    @test distance(Count{TransversionMutation}, dnas2)[2] == [5; 5; 3; 5]
+    #@test distance(Count{Kimura80}, dnas1) == ([4], [8], [16])
 
     @test distance(Count{AnyMutation}, dnas2) == ([12], [18])
     @test distance(Count{TransitionMutation}, dnas2) == ([4], [18])
@@ -91,6 +100,8 @@ end
     @test round(distance(Kimura80, dnas2)[2][1], 3) == 1
     @test round(distance(Kimura80, m2)[1][1], 3) == 1.648
     @test round(distance(Kimura80, m2)[2][1], 3) == 1
+
+
 
 end
 

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -46,6 +46,8 @@ end
 
     dnas2 = [dna"attgaacctggntttccgaa",
              dna"atacagagtatacrgtcgtc"]
+    dnas3 = [dna"attgaacctgtntttccgaa",
+             dna"atagaacgtatatrgccgtc"]
     m2 = seqmatrix(dnas2, :seq)
 
     @test distance(Count{AnyMutation}, dnas1) == ([12], [16])
@@ -114,6 +116,14 @@ end
     @test round(distance(JukesCantor69, dnas2)[2][1], 3) == 1
     @test round(distance(JukesCantor69, m2)[1][1], 3) == 1.648
     @test round(distance(JukesCantor69, m2)[2][1], 3) == 1
+    @test_throws DomainError distance(JukesCantor69, dnas2, 5, 5)
+    d = distance(JukesCantor69, dnas3, 5, 5)
+    a = [0.232616, 0.571605, 0.44084, 0.571605]
+    v = [0.0595041, 0.220408, 0.24, 0.220408]
+    for i in 1:length(d[1])
+        @test_approx_eq_eps d[1][i] a[i] 1e-5
+        @test_approx_eq_eps d[2][i] v[i] 1e-5
+    end
 
     @test round(distance(Kimura80, dnas2)[1][1], 3) == 1.648
     @test round(distance(Kimura80, dnas2)[2][1], 3) == 1

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -76,9 +76,9 @@ end
 
     @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.8, 1.0, 0.6]
     @test distance(Proportion{AnyMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
-    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[1][:] == [0.0, 0.4, 0.333, 0.2]
+    @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[1][:] == [0.0, 0.4, 0.333333, 0.2]
     @test distance(Proportion{TransitionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
-    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.4, 0.666, 0.4]
+    @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[1][:] == [0.4, 0.4, 0.666667, 0.4]
     @test distance(Proportion{TransversionMutation}, dnas2, 5, 5)[2][:] == [5, 5, 3, 5]
 
     @test distance(Proportion{AnyMutation}, dnas1) == ([(12 / 16)], [16])

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -130,8 +130,6 @@ end
     @test round(distance(Kimura80, m2)[1][1], 3) == 1.648
     @test round(distance(Kimura80, m2)[2][1], 3) == 1
 
-
-
 end
 
 end # module TestVar


### PR DESCRIPTION
A PR that allows you to compute genetic distances between sequences using a sliding window. Not the most optimal, but needed for some work being done this week here. Eventually this design will be greatly improved by PR #334.