### PR TITLE
Blast xml fix

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,6 +4,7 @@ BufferedStreams 0.2
 Colors
 Combinatorics
 Distributions
+EzXML
 IndexableBitVectors 0.1.1
 IntervalTrees 0.1
 Iterators

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,12 +4,11 @@ BufferedStreams 0.2
 Colors
 Combinatorics
 Distributions
-EzXML
+EzXML 0.2
 IndexableBitVectors 0.1.1
 IntervalTrees 0.1
 Iterators
 Libz 0.2
 LightGraphs
-LightXML
 Roots
 URIParser

--- a/src/tools/blast/BLAST.jl
+++ b/src/tools/blast/BLAST.jl
@@ -7,7 +7,7 @@ export blastn,
 
 using Bio.Seq,
       Bio.Align,
-      LightXML
+      EzXML
 
 include("blastcommandline.jl")
 

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -16,11 +16,11 @@ immutable BLASTResult
 end
 
 """
-    readblastXML(blastrun::String)
+    readblastXML(blastrun::AbstractString)
 
 Parse XML output of a blast run. Input is an XML string eg:
 ```julia
-results = readstring(open("blast_results.xml")) # need to use `readstring` instead of `readall` for v0.5
+results = readstring(open("blast_results.xml"))
 readblastXML(results)
 ```
 

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -29,10 +29,10 @@ Returns Vector{BLASTResult} with the sequence of the hit, the Alignment with que
 function readblastXML(blastrun::String; seqtype="nucl")
     dc = parsexml(blastrun)
     rt = root(dc)
-    results = Vector{BLASTResult}([])
-    for iteration in find(rt, "//BlastOutput_iterations/Iteration")
-        queryname = content(findfirst(iteration, ".//Iteration_query-def"))
-        for hit in find(iteration, ".//Iteration_hits")
+    results = BLASTResult[]
+    for iteration in find(rt, "/BlastOutput/BlastOutput_iterations/Iteration")
+        queryname = content(findfirst(iteration, "Iteration_query-def"))
+        for hit in find(iteration, "Iteration_hits")
             if countelements(hit) > 0
                 hitname = content(findfirst(hit, ".//Hit_def"))
                 hsps = findfirst(hit, ".//Hit_hsps")
@@ -78,7 +78,7 @@ Runs blastn on `query` against `subject`.
     Array of DNASequence.
     May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
 """
-function blastn(query::String, subject::String, flags=[]; db::Bool=false)
+function blastn(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
     if db
         results = readblastXML(`blastn -query $query -db $subject $flags -outfmt 5`)
     else
@@ -97,7 +97,7 @@ function blastn(query::DNASequence, subject::Vector{DNASequence}, flags=[])
     blastn(querypath, subjectpath, flags)
 end
 
-function blastn(query::DNASequence, subject::String, flags=[]; db::Bool=false)
+function blastn(query::DNASequence, subject::AbstractString, flags=[]; db::Bool=false)
     querypath = makefasta(query)
     if db
         return blastn(querypath, subject, flags, db=true)
@@ -118,7 +118,7 @@ Runs blastn on `query` against `subject`.
     Array of `BioSequence{AminoAcidSequence}`.
     May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
 """
-function blastp(query::String, subject::String, flags=[]; db::Bool=false)
+function blastp(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
     if db
         results = readblastXML(`blastp -query $query -db $subject $flags -outfmt 5`, seqtype = "prot")
     else
@@ -137,7 +137,7 @@ function blastp(query::AminoAcidSequence, subject::Vector{AminoAcidSequence}, fl
     return blastp(querypath, subjectpath, flags)
 end
 
-function blastp(query::AminoAcidSequence, subject::String, flags=[]; db::Bool=false)
+function blastp(query::AminoAcidSequence, subject::AbstractString, flags=[]; db::Bool=false)
     querypath = makefasta(query)
     if db
         return blastp(querypath, subject, flags, db=true)

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -16,7 +16,7 @@ immutable BLASTResult
 end
 
 """
-    readblastXML(blastrun::AbstractString)
+    readblastXML(blastrun::String)
 
 Parse XML output of a blast run. Input is an XML string eg:
 ```julia
@@ -26,32 +26,29 @@ readblastXML(results)
 
 Returns Vector{BLASTResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
 """
-function readblastXML(blastrun::AbstractString; seqtype="nucl")
-    xdoc = parse_string(blastrun)
-    xroot = root(xdoc)
-    params = get_elements_by_tagname(xroot, "BlastOutput_param")
-    iterations = get_elements_by_tagname(xroot, "BlastOutput_iterations")
-    results = BLASTResult[]
-    for iteration in collect(child_elements(iterations[1]))
-        queryname = content(find_element(iteration, "Iteration_query-def"))
-        hits = get_elements_by_tagname(iteration, "Iteration_hits")
-        for hit in collect(child_elements(hits[1]))
-            hitname = content(find_element(hit, "Hit_def"))
-            hsps = get_elements_by_tagname(hit, "Hit_hsps")
-            for hsp in collect(child_elements(hsps[1]))
+function readblastXML(blastrun::String; seqtype="nucl")
+    dc = parsexml(blastrun)
+    rt = root(dc)
+    results = Vector{BLASTResult}([])
+    for iteration in find(rt, "//BlastOutput_iterations/Iteration")
+        queryname = content(findfirst(iteration, ".//Iteration_query-def"))
+        for hit in find(iteration, ".//Iteration_hits")
+            if countelements(hit) > 0
+                hitname = content(findfirst(hit, ".//Hit_def"))
+                hsps = findfirst(hit, ".//Hit_hsps")
                 if seqtype == "nucl"
-                    qseq = DNASequence(content(find_element(hsp, "Hsp_qseq")))
-                    hseq = DNASequence(content(find_element(hsp, "Hsp_hseq")))
+                    qseq = DNASequence(content(findfirst(hsps, ".//Hsp_qseq")))
+                    hseq = DNASequence(content(findfirst(hsps, ".//Hsp_hseq")))
                 elseif seqtype == "prot"
-                    qseq = AminoAcidSequence(content(find_element(hsp, "Hsp_qseq")))
-                    hseq = AminoAcidSequence(content(find_element(hsp, "Hsp_hseq")))
+                    qseq = AminoAcidSequence(content(findfirst(hsps, ".//Hsp_qseq")))
+                    hseq = AminoAcidSequence(content(findfirst(hsps, ".//Hsp_hseq")))
                 else
                     throw(error("Please use \"nucl\" or \"prot\" for seqtype"))
                 end
 
                 aln = AlignedSequence(qseq, hseq)
-                bitscore = float(content(find_element(hsp, "Hsp_bit-score")))
-                expect = float(content(find_element(hsp, "Hsp_evalue")))
+                bitscore = float(content(findfirst(hsps, ".//Hsp_bit-score")))
+                expect = float(content(findfirst(hsps, ".//Hsp_evalue")))
                 push!(results, BLASTResult(bitscore, expect, queryname, hitname, hseq, aln))
             end
         end
@@ -81,7 +78,7 @@ Runs blastn on `query` against `subject`.
     Array of DNASequence.
     May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
 """
-function blastn(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
+function blastn(query::String, subject::String, flags=[]; db::Bool=false)
     if db
         results = readblastXML(`blastn -query $query -db $subject $flags -outfmt 5`)
     else
@@ -100,7 +97,7 @@ function blastn(query::DNASequence, subject::Vector{DNASequence}, flags=[])
     blastn(querypath, subjectpath, flags)
 end
 
-function blastn(query::DNASequence, subject::AbstractString, flags=[]; db::Bool=false)
+function blastn(query::DNASequence, subject::String, flags=[]; db::Bool=false)
     querypath = makefasta(query)
     if db
         return blastn(querypath, subject, flags, db=true)
@@ -121,7 +118,7 @@ Runs blastn on `query` against `subject`.
     Array of `BioSequence{AminoAcidSequence}`.
     May include optional `flag`s such as `["-perc_identity", 95,]`. Do not use `-outfmt`.
 """
-function blastp(query::AbstractString, subject::AbstractString, flags=[]; db::Bool=false)
+function blastp(query::String, subject::String, flags=[]; db::Bool=false)
     if db
         results = readblastXML(`blastp -query $query -db $subject $flags -outfmt 5`, seqtype = "prot")
     else
@@ -140,7 +137,7 @@ function blastp(query::AminoAcidSequence, subject::Vector{AminoAcidSequence}, fl
     return blastp(querypath, subjectpath, flags)
 end
 
-function blastp(query::AminoAcidSequence, subject::AbstractString, flags=[]; db::Bool=false)
+function blastp(query::AminoAcidSequence, subject::String, flags=[]; db::Bool=false)
     querypath = makefasta(query)
     if db
         return blastp(querypath, subject, flags, db=true)
@@ -157,7 +154,7 @@ end
 # Create temporary fasta-formated file for blasting.
 function makefasta(sequence::BioSequence)
     path, io = mktemp()
-    write(io, ">$path\n$(convert(AbstractString, sequence))\n")
+    write(io, ">$path\n$(convert(String, sequence))\n")
     close(io)
     return path
 end
@@ -167,7 +164,7 @@ function makefasta{T <: BioSequence}(sequences::Vector{T})
     path, io = mktemp()
     counter = 1
     for sequence in sequences
-        write(io, ">$path$counter\n$(convert(AbstractString, sequence))\n")
+        write(io, ">$path$counter\n$(convert(String, sequence))\n")
         counter += 1
     end
     close(io)

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -34,21 +34,21 @@ function readblastXML(blastrun::String; seqtype="nucl")
         queryname = content(findfirst(iteration, "Iteration_query-def"))
         for hit in find(iteration, "Iteration_hits")
             if countelements(hit) > 0
-                hitname = content(findfirst(hit, ".//Hit_def"))
-                hsps = findfirst(hit, ".//Hit_hsps")
+                hitname = content(findfirst(hit, "./Hit/Hit_def"))
+                hsps = findfirst(hit, "./Hit/Hit_hsps")
                 if seqtype == "nucl"
-                    qseq = DNASequence(content(findfirst(hsps, ".//Hsp_qseq")))
-                    hseq = DNASequence(content(findfirst(hsps, ".//Hsp_hseq")))
+                    qseq = DNASequence(content(findfirst(hsps, "./Hsp/Hsp_qseq")))
+                    hseq = DNASequence(content(findfirst(hsps, "./Hsp/Hsp_hseq")))
                 elseif seqtype == "prot"
-                    qseq = AminoAcidSequence(content(findfirst(hsps, ".//Hsp_qseq")))
-                    hseq = AminoAcidSequence(content(findfirst(hsps, ".//Hsp_hseq")))
+                    qseq = AminoAcidSequence(content(findfirst(hsps, "./Hsp/Hsp_qseq")))
+                    hseq = AminoAcidSequence(content(findfirst(hsps, "./Hsp/Hsp_hseq")))
                 else
                     throw(error("Please use \"nucl\" or \"prot\" for seqtype"))
                 end
 
                 aln = AlignedSequence(qseq, hseq)
-                bitscore = float(content(findfirst(hsps, ".//Hsp_bit-score")))
-                expect = float(content(findfirst(hsps, ".//Hsp_evalue")))
+                bitscore = float(content(findfirst(hsps, "./Hsp/Hsp_bit-score")))
+                expect = float(content(findfirst(hsps, "./Hsp/Hsp_evalue")))
                 push!(results, BLASTResult(bitscore, expect, queryname, hitname, hseq, aln))
             end
         end

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -26,7 +26,7 @@ readblastXML(results)
 
 Returns Vector{BLASTResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
 """
-function readblastXML(blastrun::String; seqtype="nucl")
+function readblastXML(blastrun::AbstractString; seqtype="nucl")
     dc = parsexml(blastrun)
     rt = root(dc)
     results = BLASTResult[]


### PR DESCRIPTION
Per request from @bicycle1885 - I altered the BLAST results parser to use EzXML rather than LightXML. This works, though I'm not sure that using XPath queries all over the place is the most efficient approach. Happy to incorporate any feedback if there's a better way.

I added EzXML to REQUIRE, but did not remove LightXML, since I think there's something else that still relies on it. 