### PR TITLE
Fix issue #369

### DIFF
--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -31,8 +31,9 @@ function StringField(data::Vector{UInt8})
 end
 
 function StringField(data::SubString)
-    part = data.string.data[1+data.offset:data.offset+nextind(data, data.endof)-1]
-    return StringField(part, 1:length(data))
+    stringvec = Vector{UInt8}(data)
+    idx = (1 + data.offset):(data.offset + nextind(data, data.endof) - 1)
+    return StringField(stringvec[idx], 1:endof(data))
 end
 
 # From base unicode/utf8.jl

--- a/src/StringFields.jl
+++ b/src/StringFields.jl
@@ -31,9 +31,13 @@ function StringField(data::Vector{UInt8})
 end
 
 function StringField(data::SubString)
-    stringvec = Vector{UInt8}(data)
-    idx = (1 + data.offset):(data.offset + nextind(data, data.endof) - 1)
+    stringvec = Vector{UInt8}(data.string)
+    idx = 1+data.offset:data.offset+nextind(data, data.endof)-1
     return StringField(stringvec[idx], 1:endof(data))
+end
+
+function StringField(data::String)
+    return StringField(Vector{UInt8}(data), 1:endof(data))
 end
 
 # From base unicode/utf8.jl

--- a/src/intervals/gff3/gff3.jl
+++ b/src/intervals/gff3/gff3.jl
@@ -37,9 +37,8 @@ function Base.haskey(attrs::GFF3Attributes, key::StringField)
     return i != 0 && attrs.used[i] > 0
 end
 
-function Base.haskey(attrs::GFF3Attributes, key_::String)
-    key = StringField(key_.data, 1:length(key_.data))
-    return haskey(attrs, key)
+function Base.haskey(attrs::GFF3Attributes, key::String)
+    return haskey(attrs, StringField(key))
 end
 
 function Base.getindex(attrs::GFF3Attributes, key::StringField)
@@ -54,9 +53,8 @@ function Base.getindex(attrs::GFF3Attributes, key::StringField)
     end
 end
 
-function Base.getindex(attrs::GFF3Attributes, key_::String)
-    key = StringField(key_.data, 1:length(key_.data))
-    return getindex(attrs, key)
+function Base.getindex(attrs::GFF3Attributes, key::String)
+    return getindex(attrs, StringField(key))
 end
 
 function pushindex!(attrs::GFF3Attributes, key::StringField,


### PR DESCRIPTION
These changes fix the concerns raised in issue #369, in preparation for julia 0.6: namely that you cannot access the raw bytes of a string using `string.data` anymore. 