### PR TITLE
fix the SAM header parser (#373)

### DIFF
--- a/src/align/hts/sam/reader.jl
+++ b/src/align/hts/sam/reader.jl
@@ -17,6 +17,7 @@ type SAMReader <: Bio.IO.AbstractReader
         reader = new(Ragel.State(samparser_start, input), SAMHeader())
         while !eof(input) && BufferedStreams.peek(input) == UInt8('@')
             # NOTE: This reads a header line, not the first record.
+            reader.state.cs = samparser_start
             @assert read(reader) == SAMRecord()
         end
         return reader


### PR DESCRIPTION
Fix a bug when reading SAM files with a large (>128KiB) header section (closes #373).