### PR TITLE
declare Bio.distance to resolve the method name conflict

### DIFF
--- a/src/Bio.jl
+++ b/src/Bio.jl
@@ -2,6 +2,7 @@ __precompile__()
 
 module Bio
 
+include("declare.jl")
 include("IO.jl")
 include("Ragel.jl")
 include("StringFields.jl")

--- a/src/align/Align.jl
+++ b/src/align/Align.jl
@@ -112,6 +112,7 @@ export
     SAM_FLAG_SUPPLEMENTARY
 
 import Bio
+import Bio: distance
 using Bio.Seq
 using Bio.Intervals
 import Bio.StringFields: StringField

--- a/src/align/pairwise/result.jl
+++ b/src/align/pairwise/result.jl
@@ -42,7 +42,7 @@ score(aln::PairwiseAlignmentResult) = aln.value
 
 Retrun distance of alignment.
 """
-distance(aln::PairwiseAlignmentResult) = aln.value
+Bio.distance(aln::PairwiseAlignmentResult) = aln.value
 
 
 """

--- a/src/declare.jl
+++ b/src/declare.jl
@@ -1,0 +1,17 @@
+# Method Declarations
+# ===================
+
+# Method declaration macro.
+macro declare(names)
+    @assert names.head == :tuple
+    ex = Expr(:block)
+    for name in names.args
+        push!(ex.args, :(function $(name) end))
+        push!(ex.args, :(export $(name)))
+    end
+    return esc(ex)
+end
+
+@declare (
+    distance,
+)

--- a/src/phylo/Phylo.jl
+++ b/src/phylo/Phylo.jl
@@ -7,8 +7,6 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-
-
 module Phylo
 
 using LightGraphs

--- a/src/structure/Structure.jl
+++ b/src/structure/Structure.jl
@@ -8,7 +8,8 @@
 
 module Structure
 
-import Bio.IO.FileFormat
+import Bio
+import Bio: distance
 
 include("model.jl")
 include("pdb.jl")

--- a/src/structure/pdb.jl
+++ b/src/structure/pdb.jl
@@ -8,7 +8,7 @@ export
 
 
 "Protein Data Bank (PDB) file format."
-immutable PDB <: FileFormat end
+immutable PDB <: Bio.IO.FileFormat end
 
 
 "Error arising from parsing a Protein Data Bank (PDB) file."

--- a/src/structure/spatial.jl
+++ b/src/structure/spatial.jl
@@ -116,13 +116,13 @@ Get the minimum distance between two `StructuralElementOrList`s.
 Additional arguments are atom selector functions - only atoms that return
 `true` from the functions are retained.
 """
-function distance(el_one::StructuralElementOrList,
-                el_two::StructuralElementOrList,
-                atom_selectors::Function...)
+function Bio.distance(el_one::StructuralElementOrList,
+                      el_two::StructuralElementOrList,
+                      atom_selectors::Function...)
     return sqrt(sqdistance(el_one, el_two, atom_selectors...))
 end
 
-function distance(at_one::AbstractAtom, at_two::AbstractAtom)
+function Bio.distance(at_one::AbstractAtom, at_two::AbstractAtom)
     return sqrt(sqdistance(at_one, at_two))
 end
 

--- a/src/var/Var.jl
+++ b/src/var/Var.jl
@@ -8,6 +8,9 @@
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 module Var
+
+import Bio
+import Bio: distance
 using Bio.Seq
 
 export

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -111,13 +111,15 @@ end
 # Distance computation methods
 # ----------------------------
 
+#=
 """
 Compute the pairwise genetic distances for a set of aligned nucleotide sequences.
 
 The distance measure to compute is determined by the type provided as the first
 parameter. The second parameter provides the set of nucleotide sequences.
 """
-function distance end
+function Bio.distance end
+=#
 
 """
     distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
@@ -129,7 +131,7 @@ This method of distance returns a tuple of the number of mutations of type `T`
 between sequences and the number of valid (i.e. non-ambiguous sites) counted by
 the function.
 """
-function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
+function Bio.distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
     return count_mutations(T, seqs)
 end
 
@@ -145,7 +147,7 @@ This method computes mutation counts for every window, and returns a tuple of th
 matrix of p-distances for every window, a matrix of the number of valid sites
 counted by the function for each window.
 """
-function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function Bio.distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     mutation_flags, ambiguous_flags = flagmutations(T, seqs)
     nbases, npairs = size(mutation_flags)
     if width < 1
@@ -186,7 +188,7 @@ function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs:
 end
 
 
-function distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function Bio.distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     transitionFlags, transversionFlags, ambiguous_flags = flagmutations(TransitionMutation, TransversionMutation, seqs)
     nbases, npairs = size(transitionFlags)
     if width < 1
@@ -245,15 +247,15 @@ the function.
 provided as `seqs` in sequence major order i.e. each column of the matrix is one
 complete nucleotide sequence.**
 """
-function distance{T<:MutationType,N<:Nucleotide}(::Type{Count{T}}, seqs::Matrix{N})
+function Bio.distance{T<:MutationType,N<:Nucleotide}(::Type{Count{T}}, seqs::Matrix{N})
     return count_mutations(T, seqs)
 end
 
-function distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
+function Bio.distance{T<:TsTv,A<:NucleotideAlphabet}(::Type{Count{T}}, seqs::Vector{BioSequence{A}})
     return count_mutations(TransitionMutation, TransversionMutation, seqs)
 end
 
-function distance{T<:TsTv,N<:Nucleotide}(::Type{Count{T}}, seqs::Matrix{N})
+function Bio.distance{T<:TsTv,N<:Nucleotide}(::Type{Count{T}}, seqs::Matrix{N})
     return count_mutations(TransitionMutation, TransversionMutation, seqs)
 end
 
@@ -263,7 +265,7 @@ end
 This method of distance returns a tuple of a vector of the p-distances, and a
 vector of the number of valid (i.e. non-ambiguous sites) counted by the function.
 """
-function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}})
+function Bio.distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}})
     d, l = distance(Count{T}, seqs)
     D = Vector{Float64}(length(d))
     @inbounds @simd for i in 1:length(D)
@@ -282,7 +284,7 @@ vector of the number of valid (i.e. non-ambiguous) sites counted by the function
 provided as `seqs` in sequence major order i.e. each column of the matrix is one
 complete nucleotide sequence.**
 """
-function distance{T<:MutationType,N<:Nucleotide}(::Type{Proportion{T}}, seqs::Matrix{N})
+function Bio.distance{T<:MutationType,N<:Nucleotide}(::Type{Proportion{T}}, seqs::Matrix{N})
     d, l = distance(Count{T}, seqs)
     D = Vector{Float64}(length(d))
     @inbounds for i in 1:length(D)
@@ -303,7 +305,7 @@ This method computes p-distances for every window, and returns a tuple of the
 matrix of p-distances for every window, a matrix of the number of valid sites
 counted by the function for each window.
 """
-function distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function Bio.distance{T<:MutationType,A<:NucleotideAlphabet}(::Type{Proportion{T}}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     counts, wsizes, ranges = distance(Count{T}, seqs, width, step)
     res = Matrix{Float64}(size(counts))
     @inbounds for i in 1:endof(counts)
@@ -318,7 +320,7 @@ end
 This method of distance returns a tuple of the expected JukesCantor69 distance
 estimate, and the computed variance.
 """
-function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}})
+function Bio.distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}})
     p, l = distance(Proportion{AnyMutation}, seqs)
     D = Vector{Float64}(length(p))
     V = Vector{Float64}(length(p))
@@ -341,7 +343,7 @@ This method computes the JukesCantor69 distance for every window, and returns a 
 matrix of p-distances for every window, a matrix of the number of valid sites
 counted by the function for each window.
 """
-function distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function Bio.distance{A<:NucleotideAlphabet}(::Type{JukesCantor69}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     ps, wsizes, ranges = distance(Proportion{AnyMutation}, seqs, width, step)
     a, b = size(ps)
     est = Matrix{Float64}(a, b)
@@ -365,7 +367,7 @@ estimate, and the computed variance.
 provided as `seqs` in sequence major order i.e. each column of the matrix is one
 complete nucleotide sequence.**
 """
-function distance{N<:Nucleotide}(::Type{JukesCantor69}, seqs::Matrix{N})
+function Bio.distance{N<:Nucleotide}(::Type{JukesCantor69}, seqs::Matrix{N})
     p, l = distance(Proportion{AnyMutation}, seqs)
     D = Vector{Float64}(length(p))
     V = Vector{Float64}(length(p))
@@ -383,7 +385,7 @@ end
 This method of distance returns a tuple of the expected Kimura80 distance
 estimate, and the computed variance.
 """
-function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}})
+function Bio.distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}})
     ns, nv, l = distance(Count{Kimura80}, seqs)
     D = Vector{Float64}(length(ns))
     V = Vector{Float64}(length(ns))
@@ -411,7 +413,7 @@ This method computes the Kimura80 distance for every window, and returns a tuple
 matrix of p-distances for every window, a matrix of the number of valid sites
 counted by the function for each window.
 """
-function distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
+function Bio.distance{A<:NucleotideAlphabet}(::Type{Kimura80}, seqs::Vector{BioSequence{A}}, width::Int, step::Int)
     tss, tvs, wsizes, ranges = distance(Count{Kimura80}, seqs, width, step)
     a, b = size(tss)
     est = Matrix{Float64}(a, b)
@@ -440,7 +442,7 @@ estimate, and the computed variance.
 provided as `seqs` in sequence major order i.e. each column of the matrix is one
 complete nucleotide sequence.**
 """
-function distance{N<:Nucleotide}(::Type{Kimura80}, seqs::Matrix{N})
+function Bio.distance{N<:Nucleotide}(::Type{Kimura80}, seqs::Matrix{N})
     ns, nv, l = distance(Count{Kimura80}, seqs)
     D = Vector{Float64}(length(ns))
     V = Vector{Float64}(length(ns))


### PR DESCRIPTION
This resolves a method name conflict that happens between sub-modules of Bio.jl. The `distance` function is defined in three sub-modules: `Bio.Align`, `Bio.Structure` and `Bio.Var`. This is problematic when we call `using` two of them:
```
julia> using Bio.Align, Bio.Var
INFO: Recompiling stale cache file /Users/kenta/.julia/lib/v0.5/Bio.ji for module Bio.
INFO: compiling FASTA

julia> distance
WARNING: both Var and Align export "distance"; uses of it in module Main must be qualified
ERROR: UndefVarError: distance not defined

```

This patch declares the `distance` function in `Bio` and extends it in each submodule. If this approach works well, I'd like to use it more pervasively in Bio.jl.

CC: @Ward9250 and @jgreener64. 