### PR TITLE
deactivate Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.build("Bio"); Pkg.test("Bio"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Bio")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  # Deactivate Coveralls for a while; we'll remove it when we find it unnecessary.
+  # - julia -e 'cd(Pkg.dir("Bio")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
   - julia -e 'cd(Pkg.dir("Bio")); Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
   - julia -e 'cd(Pkg.dir("Bio")); Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ _The Bioinformatics and Computation Biology infrastructure for the julia languag
 
 | **Chat** | **Documentation** | **Build Status** |
 |:--------:|:-----------------:|:----------------:|
-| [![][gitter-img]][gitter-url] | [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] [![][coveralls-img]][coveralls-url] |
+| [![][gitter-img]][gitter-url] | [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 
 ## Description
@@ -94,8 +94,6 @@ Our roadmap is on the wiki: <https://github.com/BioJulia/Bio.jl/wiki/roadmap>.
 
 [codecov-img]: https://codecov.io/gh/BioJulia/Bio.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/BioJulia/Bio.jl
-[coveralls-img]:  https://img.shields.io/coveralls/BioJulia/Bio.jl.svg
-[coveralls-url]: https://coveralls.io/r/BioJulia/Bio.jl
 [travis-img]: https://travis-ci.org/BioJulia/Bio.jl.svg?branch=master
 [travis-url]: https://travis-ci.org/BioJulia/Bio.jl
 [appveyor-img]: https://ci.appveyor.com/api/projects/status/nq4w264346py8esp/branch/master?svg=true


### PR DESCRIPTION
This deactivates Coveralls. We already use two coverage tracking systems: [codecov](https://codecov.io/gh/BioJulia/Bio.jl) and [coveralls](https://coveralls.io/github/BioJulia/Bio.jl). This is redundant and I think it would be better to remove one of them. To my eyes, the interfaces of Coveralls are less intuitive and its reporting is [too verbose](https://github.com/BioJulia/Bio.jl/pull/378). [Automa.jl](https://github.com/BioJulia/Automa.jl) and [EzXML.jl](https://github.com/bicycle1885/EzXML.jl) have already dropped Coveralls for this reason.