### PR TITLE
Tidy import

### DIFF
--- a/src/Ragel.jl
+++ b/src/Ragel.jl
@@ -10,8 +10,8 @@ module Ragel
 
 export tryread!
 
-using BufferedStreams
 import Bio.IO: FileFormat, AbstractReader, stream
+import BufferedStreams: BufferedStreams, BufferedInputStream
 
 # A type keeping track of a ragel-based parser's state.
 type State{T<:BufferedInputStream}

--- a/src/align/Align.jl
+++ b/src/align/Align.jl
@@ -96,7 +96,7 @@ export
     seqlength,
     qualities,
     header,
-    isoverlapping,  # re-export from Bio.Intervals
+    isoverlapping,
     # SAM flags
     SAM_FLAG_PAIRED,
     SAM_FLAG_PROPER_PAIR,
@@ -111,11 +111,12 @@ export
     SAM_FLAG_DUP,
     SAM_FLAG_SUPPLEMENTARY
 
-importall Bio
-using Bio.Seq
-using Bio.Intervals
+import BGZFStreams
+import Bio.Ragel: Ragel
 import Bio.StringFields: StringField
+import BufferedStreams
 import IntervalTrees
+importall Bio
 
 include("operations.jl")
 include("anchors.jl")

--- a/src/align/alignedseq.jl
+++ b/src/align/alignedseq.jl
@@ -16,12 +16,12 @@ function AlignedSequence{S}(seq::S, anchors::Vector{AlignmentAnchor},
     return AlignedSequence(seq, Alignment(anchors, check))
 end
 
-function AlignedSequence(seq::Sequence, ref::Sequence)
+function AlignedSequence(seq::Bio.Seq.Sequence, ref::Bio.Seq.Sequence)
     return AlignedSequence(seq, 1, ref, 1)
 end
 
-function AlignedSequence(seq::Sequence, seqpos::Integer,
-                         ref::Sequence, refpos::Integer)
+function AlignedSequence(seq::Bio.Seq.Sequence, seqpos::Integer,
+                         ref::Bio.Seq.Sequence, refpos::Integer)
     if length(seq) != length(ref)
         throw(ArgumentError("two sequences must be the same length"))
     end
@@ -31,11 +31,11 @@ function AlignedSequence(seq::Sequence, seqpos::Integer,
     newseq = similar(seq, 0)  # sequence without gap symbols
     anchors = AlignmentAnchor[]
     for (x, y) in zip(seq, ref)
-        if x == gap(eltype(seq)) && y == gap(eltype(ref))
+        if x == Bio.Seq.gap(eltype(seq)) && y == Bio.Seq.gap(eltype(ref))
             throw(ArgumentError("two sequences must not have gaps at the same position"))
-        elseif x == gap(eltype(seq))
+        elseif x == Bio.Seq.gap(eltype(seq))
             op′ = OP_DELETE
-        elseif y == gap(eltype(ref))
+        elseif y == Bio.Seq.gap(eltype(ref))
             op′ = OP_INSERT
         elseif x == y
             op′ = OP_SEQ_MATCH
@@ -48,11 +48,11 @@ function AlignedSequence(seq::Sequence, seqpos::Integer,
             op = op′
         end
 
-        if x != gap(eltype(seq))
+        if x != Bio.Seq.gap(eltype(seq))
             seqpos += 1
             push!(newseq, x)
         end
-        if y != gap(eltype(ref))
+        if y != Bio.Seq.gap(eltype(ref))
             refpos += 1
         end
     end

--- a/src/align/hts/bam/bai.jl
+++ b/src/align/hts/bam/bai.jl
@@ -9,7 +9,7 @@
 # An index type for the BAM file format.
 type BAI
     # BGZF file index
-    index::BGZFIndex
+    index::Bio.Intervals.BGZFIndex
 
     # number of unmapped reads
     n_no_coors::Nullable{Int}

--- a/src/align/hts/bam/reader.jl
+++ b/src/align/hts/bam/reader.jl
@@ -11,9 +11,9 @@ Create a data reader of the BAM file format.
 * `index=nothing`: filepath to a random access index (currently *bai* is Supported)
 """
 type BAMReader{T} <: Bio.IO.AbstractReader
-    stream::BGZFStream{T}
+    stream::BGZFStreams.BGZFStream{T}
     header::SAMHeader
-    start_offset::VirtualOffset
+    start_offset::BGZFStreams.VirtualOffset
     refseqnames::Vector{String}
     refseqlens::Vector{Int}
     index::Nullable{BAI}
@@ -61,7 +61,7 @@ function header(reader::BAMReader, fillSQ::Bool=false)
     return reader.header
 end
 
-function Base.seek(reader::BAMReader, voffset::VirtualOffset)
+function Base.seek(reader::BAMReader, voffset::BGZFStreams.VirtualOffset)
     seek(reader.stream, voffset)
 end
 
@@ -71,7 +71,7 @@ end
 
 # Initialize a BAM reader by reading the header section.
 function init_bam_reader(input::IO)
-    stream = BGZFStream(input)
+    stream = BGZFStreams.BGZFStream(input)
 
     # magic bytes
     B = read(stream, UInt8)
@@ -102,7 +102,7 @@ function init_bam_reader(input::IO)
     reader = BAMReader(
         stream,
         samheader,
-        isa(input, Pipe) ? VirtualOffset(0, 0) : virtualoffset(stream),
+        isa(input, Pipe) ? BGZFStreams.VirtualOffset(0, 0) : BGZFStreams.virtualoffset(stream),
         refseqnames,
         refseqlens,
         Nullable{BAI}())

--- a/src/align/hts/bam/writer.jl
+++ b/src/align/hts/bam/writer.jl
@@ -11,10 +11,10 @@ Create a data writer of the BAM file format.
 * `header`: SAM header object
 """
 type BAMWriter <: Bio.IO.AbstractWriter
-    stream::BGZFStream
+    stream::BGZFStreams.BGZFStream
 end
 
-function BAMWriter(stream::BGZFStream, header::SAMHeader)
+function BAMWriter(stream::BGZFStreams.BGZFStream, header::SAMHeader)
     refseqnames = String[]
     refseqlens = Int[]
     for rec in header["SQ"]

--- a/src/align/hts/hts.jl
+++ b/src/align/hts/hts.jl
@@ -6,12 +6,6 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-import Bio: Ragel
-import Bio.Intervals: Chunk, BGZFIndex, BinIndex, LinearIndex, PseudoBin, LinearWindowSize
-import BGZFStreams: BGZFStream, VirtualOffset, virtualoffset
-import BufferedStreams   # this is necessary though I don't know why.
-import BufferedStreams: BufferedInputStream
-
 include("sam/sam.jl")
 include("bam/bam.jl")
 

--- a/src/align/hts/sam/reader.jl
+++ b/src/align/hts/sam/reader.jl
@@ -13,7 +13,7 @@ type SAMReader <: Bio.IO.AbstractReader
     state::Ragel.State
     header::SAMHeader
 
-    function SAMReader(input::BufferedInputStream)
+    function SAMReader(input::BufferedStreams.BufferedInputStream)
         reader = new(Ragel.State(samparser_start, input), SAMHeader())
         while !eof(input) && BufferedStreams.peek(input) == UInt8('@')
             # NOTE: This reads a header line, not the first record.
@@ -25,7 +25,7 @@ type SAMReader <: Bio.IO.AbstractReader
 end
 
 function SAMReader(input::IO)
-    return SAMReader(BufferedInputStream(input))
+    return SAMReader(BufferedStreams.BufferedInputStream(input))
 end
 
 function Bio.IO.stream(reader::SAMReader)

--- a/src/align/pairwise/alignment.jl
+++ b/src/align/pairwise/alignment.jl
@@ -30,9 +30,9 @@ function Base.next(aln::PairwiseAlignment, ij)
         y = ref[refpos + j]
     elseif isinsertop(anchor.op)
         x = seq[seqpos + j]
-        y = gap(eltype(ref))
+        y = Bio.Seq.gap(eltype(ref))
     elseif isdeleteop(anchor.op)
-        x = gap(eltype(seq))
+        x = Bio.Seq.gap(eltype(seq))
         y = ref[refpos + j]
     else
         @assert false
@@ -163,10 +163,10 @@ function Base.print(io::IO, aln::PairwiseAlignment, width::Integer=60)
         (x, y), s = next(aln, s)
 
         i += 1
-        if x != gap(eltype(seq))
+        if x != Bio.Seq.gap(eltype(seq))
             seqpos += 1
         end
-        if y != gap(eltype(ref))
+        if y != Bio.Seq.gap(eltype(ref))
             refpos += 1
         end
 

--- a/src/align/submat.jl
+++ b/src/align/submat.jl
@@ -26,7 +26,7 @@ immutable SubstitutionMatrix{T,S} <: AbstractSubstitutionMatrix{S}
 
     function SubstitutionMatrix(data::Matrix{S}, defined::BitMatrix)
         @assert size(data) == size(defined)
-        @assert size(data, 1) == size(data, 2) == length(alphabet(T)) - 1
+        @assert size(data, 1) == size(data, 2) == length(Bio.Seq.alphabet(T)) - 1
         return new(data, defined)
     end
 
@@ -62,7 +62,7 @@ end
 
 function SubstitutionMatrix{T,S}(scores::Associative{Tuple{T,T},S};
                                  default_match=S(0), default_mismatch=S(0))
-    n = length(alphabet(T)) - 1
+    n = length(Bio.Seq.alphabet(T)) - 1
     submat = Matrix{S}(n, n)
     defined = falses(n, n)
     for ((x, y), score) in scores
@@ -131,16 +131,16 @@ underline(s) = join([string(c, '\U0332') for c in s])
 
 # Return a vector of all symbols of `T` except the gap symbol.
 function alphabet_without_gap{T}(::Type{T})
-    return filter!(x -> x != gap(T), collect(alphabet(T)))
+    return filter!(x -> x != Bio.Seq.gap(T), collect(Bio.Seq.alphabet(T)))
 end
 
 # Return the row/column index of `nt`.
-function index(nt::Nucleotide)
+function index(nt::Bio.Seq.Nucleotide)
     return convert(Int, nt)
 end
 
 # Return the row/column index of `aa`.
-function index(aa::AminoAcid)
+function index(aa::Bio.Seq.AminoAcid)
     return convert(Int, aa) + 1
 end
 
@@ -160,7 +160,7 @@ end
 
 function Base.convert{T,S}(::Type{SubstitutionMatrix{T,S}},
                            submat::DichotomousSubstitutionMatrix)
-    n = length(alphabet(T)) - 1
+    n = length(Bio.Seq.alphabet(T)) - 1
     data = Matrix{S}(n, n)
     fill!(data, submat.mismatch)
     data[diagind(data)] = submat.match
@@ -217,12 +217,12 @@ function parse_ncbi_submat{T}(::Type{T}, filepath)
     return SubstitutionMatrix(scores, default_match=0, default_mismatch=0)
 end
 
-const EDNAFULL = load_submat(DNANucleotide, "NUC.4.4")
-const PAM30    = load_submat(AminoAcid, "PAM30")
-const PAM70    = load_submat(AminoAcid, "PAM70")
-const PAM250   = load_submat(AminoAcid, "PAM250")
-const BLOSUM45 = load_submat(AminoAcid, "BLOSUM45")
-const BLOSUM50 = load_submat(AminoAcid, "BLOSUM50")
-const BLOSUM62 = load_submat(AminoAcid, "BLOSUM62")
-const BLOSUM80 = load_submat(AminoAcid, "BLOSUM80")
-const BLOSUM90 = load_submat(AminoAcid, "BLOSUM90")
+const EDNAFULL = load_submat(Bio.Seq.DNANucleotide, "NUC.4.4")
+const PAM30    = load_submat(Bio.Seq.AminoAcid, "PAM30")
+const PAM70    = load_submat(Bio.Seq.AminoAcid, "PAM70")
+const PAM250   = load_submat(Bio.Seq.AminoAcid, "PAM250")
+const BLOSUM45 = load_submat(Bio.Seq.AminoAcid, "BLOSUM45")
+const BLOSUM50 = load_submat(Bio.Seq.AminoAcid, "BLOSUM50")
+const BLOSUM62 = load_submat(Bio.Seq.AminoAcid, "BLOSUM62")
+const BLOSUM80 = load_submat(Bio.Seq.AminoAcid, "BLOSUM80")
+const BLOSUM90 = load_submat(Bio.Seq.AminoAcid, "BLOSUM90")

--- a/src/declare.jl
+++ b/src/declare.jl
@@ -24,4 +24,5 @@ end
     metadata,
     leftposition,
     rightposition,
+    isoverlapping,
 )

--- a/src/intervals/Intervals.jl
+++ b/src/intervals/Intervals.jl
@@ -37,26 +37,17 @@ export
     getfasta,
     directives,
     Tabix,
-    overlapchunks
+    overlapchunks,
+    tryread!
 
-import ..Ragel: tryread!
-export tryread!
-
-importall Bio
+import Base.Collections: heappush!, heappop!
+import Bio.Ragel: Ragel, tryread!
+import Bio.StringFields: StringField
+import BufferedStreams: BufferedStreams, BufferedInputStream, upanchor!
 import ColorTypes: RGB
-using
-    BufferedStreams,
-    IntervalTrees,
-    Libz,
-    Bio.Ragel,
-    Bio.StringFields,
-    Bio.Seq
-
-using Base.Collections:
-    heappush!,
-    heappop!
-
-import Iterators
+import IntervalTrees
+import Libz
+importall Bio
 
 include("strand.jl")
 include("interval.jl")

--- a/src/intervals/bbi/intersection.jl
+++ b/src/intervals/bbi/intersection.jl
@@ -153,7 +153,7 @@ function find_next_intersection!(it::BigBedIntersectIterator)
 
             seek(it.bb.stream, block_offset)
             @assert block_size <= length(it.bb.uncompressed_data)
-            unc_block_size = readbytes!(ZlibInflateInputStream(it.bb.stream, reset_on_end=false),
+            unc_block_size = readbytes!(Libz.ZlibInflateInputStream(it.bb.stream, reset_on_end=false),
                                         it.bb.uncompressed_data,
                                         length(it.bb.uncompressed_data))
             it.reader = BigBedDataReader(

--- a/src/intervals/bbi/reader.jl
+++ b/src/intervals/bbi/reader.jl
@@ -206,7 +206,7 @@ function Base.start(bb::BigBedReader)
     # read the first data block
     seek(bb.stream, bb.header.full_data_offset)
     data_count = read(bb.stream, UInt64)
-    zlib_stream = ZlibInflateInputStream(bb.stream, reset_on_end=false)
+    zlib_stream = Libz.ZlibInflateInputStream(bb.stream, reset_on_end=false)
     unc_block_size = readbytes!(zlib_stream, bb.uncompressed_data,
                                length(bb.uncompressed_data))
 
@@ -234,7 +234,7 @@ function Base.next(bb::BigBedReader, state::BigBedIteratorState)
 
     if state.reader_isdone
         seek(bb.stream, bb.header.full_data_offset + state.data_offset + sizeof(UInt64))
-        zlib_stream = ZlibInflateInputStream(bb.stream, reset_on_end=false)
+        zlib_stream = Libz.ZlibInflateInputStream(bb.stream, reset_on_end=false)
 
         unc_block_size = readbytes!(zlib_stream, bb.uncompressed_data,
                                     length(bb.uncompressed_data))

--- a/src/intervals/bbi/writer.jl
+++ b/src/intervals/bbi/writer.jl
@@ -289,7 +289,7 @@ function bigbed_write_blocks(out::IO, intervals::IntervalCollection,
             max_block_size = max(max_block_size, length(block))
 
             if compressed
-                writer = ZlibDeflateOutputStream(out)
+                writer = Libz.ZlibDeflateOutputStream(out)
                 write(writer, block)
                 flush(writer)
             else
@@ -357,7 +357,7 @@ function bigwig_write_blocks{T<:Number}(out::IO, intervals::IntervalCollection{T
                                          0, 0, BIGWIG_DATATYPE_BEDGRAPH, 0, item_ix - 1)
 
             if compressed
-                writer = ZlibDeflateOutputStream(out)
+                writer = Libz.ZlibDeflateOutputStream(out)
                 write(writer, header)
                 for i in 1:item_ix-1
                     write(writer, items[i])
@@ -895,7 +895,7 @@ function bigbed_write_summary_and_index_comp(
     i = 1
     while items_left > 0
         items_in_slot = min(items_per_slot, items_left)
-        writer = ZlibDeflateOutputStream(out)
+        writer = Libz.ZlibDeflateOutputStream(out)
         file_pos = position(out)
         for _ in 1:items_in_slot
             summary = summary_list[sum_ix]

--- a/src/intervals/gff3/reader.jl
+++ b/src/intervals/gff3/reader.jl
@@ -99,5 +99,5 @@ function getfasta(reader::GFF3Reader)
     if !hasfasta(reader)
         error("GFF3 file has no FASTA data ")
     end
-    return FASTAReader(reader.state.stream)
+    return Bio.Seq.FASTAReader(reader.state.stream)
 end

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -8,7 +8,7 @@
 
 # Note, just to be clear: this shadows IntervalTrees.Interval
 "A genomic interval specifies interval with some associated metadata"
-type Interval{T} <: AbstractInterval{Int64}
+type Interval{T} <: IntervalTrees.AbstractInterval{Int64}
     seqname::StringField
     first::Int64
     last::Int64

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -122,7 +122,7 @@ function Base.:(==){T}(a::Interval{T}, b::Interval{T})
 end
 
 "Return true if interval `a` overlaps interval `b`, with no consideration to strand"
-function isoverlapping{S, T}(a::Interval{S}, b::Interval{T})
+function Bio.isoverlapping{S, T}(a::Interval{S}, b::Interval{T})
     return a.first <= b.last && b.first <= a.last && a.seqname == b.seqname
 end
 

--- a/src/intervals/intervalcollection.jl
+++ b/src/intervals/intervalcollection.jl
@@ -32,7 +32,7 @@
 #       ordered iteration.             ...
 #
 
-typealias IntervalCollectionTree{T} IntervalTree{Int64,Interval{T}}
+typealias IntervalCollectionTree{T} IntervalTrees.IntervalTree{Int64,Interval{T}}
 
 type IntervalCollection{T} <: IntervalStream{T}
     # Sequence name mapped to IntervalTree, which in turn maps intervals to

--- a/src/intervals/intervalstream.jl
+++ b/src/intervals/intervalstream.jl
@@ -220,7 +220,7 @@ coverage like:
 
     [1][-2-][-1-][--2--][--1--]
 """
-function coverage(stream::Union{IntervalStreamOrArray, IntervalTree},
+function coverage(stream::Union{IntervalStreamOrArray,IntervalTrees.IntervalTree},
                   seqname_isless::Function=isless)
     cov = IntervalCollection{UInt32}()
     lasts = Int64[]

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -153,22 +153,18 @@ export
     Demultiplexer,
     demultiplex,
     seqmatrix,
-    majorityvote
+    majorityvote,
+    tryread!
 
-importall Bio
 import Automa
 import Automa.RegExp: @re_str
-const re = Automa.RegExp
-using
-    BufferedStreams,
-    Iterators,
-    IndexableBitVectors,
-    Bio.Ragel,
-    Bio.StringFields,
-    Combinatorics
-
-import ..Ragel: tryread!
-export tryread!
+import Bio.Ragel: Ragel, tryread!
+import Bio.StringFields: StringField
+import BufferedStreams: BufferedStreams, BufferedInputStream, BufferedOutputStream
+import Combinatorics
+import IndexableBitVectors
+import Iterators
+importall Bio
 
 """
     alphabet(typ)

--- a/src/seq/demultiplexer.jl
+++ b/src/seq/demultiplexer.jl
@@ -231,8 +231,8 @@ function hamming_circle(seq, m)
         return [seq]
     end
     ret = DNASequence[]
-    for ps in combinations(1:endof(seq), m)
-        for rs in product(repeated(1:4, m)...)
+    for ps in Combinatorics.combinations(1:endof(seq), m)
+        for rs in Iterators.product(repeated(1:4, m)...)
             seq′ = copy(seq)
             for (p, r) in zip(ps, rs)
                 if findfirst(ACGT, seq[p]) ≤ r

--- a/src/seq/fasta/reader.jl
+++ b/src/seq/fasta/reader.jl
@@ -101,6 +101,8 @@ end
 
 info("compiling FASTA")
 const fasta_machine = (function ()
+    re = Automa.RegExp
+
     lf          = re"\n"
     newline     = re"\r?" * lf
     hspace      = re"[ \t\v]"

--- a/src/seq/nmask.jl
+++ b/src/seq/nmask.jl
@@ -7,13 +7,13 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 immutable NMask
-    blockmask::SucVector
+    blockmask::IndexableBitVectors.SucVector
     blocks::Vector{UInt64}
     len::Int
 end
 
 function NMask()
-    return NMask(SucVector(), UInt64[], 0)
+    return NMask(IndexableBitVectors.SucVector(), UInt64[], 0)
 end
 
 Base.copy(nmask::NMask) = NMask(copy(nmask.blockmask), copy(nmask.blocks), nmask.len)
@@ -62,7 +62,7 @@ end
     if !IndexableBitVectors.unsafe_getindex(nmask.blockmask, blockid)
         return false
     end
-    block = nmask.blocks[rank1(nmask.blockmask, blockid)]
+    block = nmask.blocks[IndexableBitVectors.rank1(nmask.blockmask, blockid)]
     return ((block >> (bitid - 1)) & 1) == 1
 end
 
@@ -73,7 +73,7 @@ function findnextn(nmask::NMask, i::Integer)
     blockid, bitid = block_bit(i)
     if nmask.blockmask[blockid]
         # try to find in the current block
-        block = nmask.blocks[rank1(nmask.blockmask, blockid)]
+        block = nmask.blocks[IndexableBitVectors.rank1(nmask.blockmask, blockid)]
         d = findnext_in_block(block, bitid)
         if d > 0
             # found in the block
@@ -81,11 +81,11 @@ function findnextn(nmask::NMask, i::Integer)
         end
     end
     # search in the following blocks
-    blockid = search1(nmask.blockmask, blockid + 1)
+    blockid = IndexableBitVectors.search1(nmask.blockmask, blockid + 1)
     if blockid == 0
         return 0
     end
-    block = nmask.blocks[rank1(nmask.blockmask, blockid)]
+    block = nmask.blocks[IndexableBitVectors.rank1(nmask.blockmask, blockid)]
     d = findnext_in_block(block, 1)
     @assert d > 0
     return 64 * (blockid - 1) + d
@@ -103,7 +103,7 @@ function findprevn(nmask::NMask, i::Integer)
     blockid, bitid = block_bit(i)
     if nmask.blockmask[blockid]
         # try to find in the current block
-        block = nmask.blocks[rank1(nmask.blockmask, blockid)]
+        block = nmask.blocks[IndexableBitVectors.rank1(nmask.blockmask, blockid)]
         d = findprev_in_block(block, bitid)
         if d > 0
             # found in the block
@@ -111,11 +111,11 @@ function findprevn(nmask::NMask, i::Integer)
         end
     end
     # search in the following blocks
-    blockid = rsearch1(nmask.blockmask, blockid - 1)
+    blockid = IndexableBitVectors.rsearch1(nmask.blockmask, blockid - 1)
     if blockid == 0
         return 0
     end
-    block = nmask.blocks[rank1(nmask.blockmask, blockid)]
+    block = nmask.blocks[IndexableBitVectors.rank1(nmask.blockmask, blockid)]
     d = findprev_in_block(block, 64)
     @assert d > 0
     return 64 * (blockid - 1) + d

--- a/src/structure/Structure.jl
+++ b/src/structure/Structure.jl
@@ -8,6 +8,7 @@
 
 module Structure
 
+import Bio.Seq: AminoAcidSequence
 importall Bio
 
 include("model.jl")

--- a/src/structure/model.jl
+++ b/src/structure/model.jl
@@ -88,11 +88,6 @@ export
     AminoAcidSequence
 
 
-using Bio.Seq
-import Bio.Seq.AminoAcidSequence
-import Bio.Seq.threeletter_to_aa
-
-
 "A macromolecular structural element."
 abstract StructuralElement
 
@@ -1465,24 +1460,24 @@ end
 
 # Residues are ordered in a chain with all hetero residues at the end
 # For obtaining sequence we will re-order them numerically
-function AminoAcidSequence(ch::Chain, residue_selectors::Function...)
-    return AminoAcidSequence(
+function Bio.Seq.AminoAcidSequence(ch::Chain, residue_selectors::Function...)
+    return Bio.Seq.AminoAcidSequence(
         sort(collectresidues(ch, residue_selectors...), by=resnumber))
 end
 
-function AminoAcidSequence{T <: AbstractResidue}(res::Vector{T})
-    seq = AminoAcid[]
+function Bio.Seq.AminoAcidSequence{T <: AbstractResidue}(res::Vector{T})
+    seq = Bio.Seq.AminoAcid[]
     for i in 1:length(res)
-        if haskey(threeletter_to_aa, resname(res[i]))
-            push!(seq, threeletter_to_aa[resname(res[i])])
+        if haskey(Bio.Seq.threeletter_to_aa, resname(res[i]))
+            push!(seq, Bio.Seq.threeletter_to_aa[resname(res[i])])
         else
-            push!(seq, AA_X)
+            push!(seq, Bio.Seq.AA_X)
         end
         if i+1 <= length(res) && resnumber(res[i+1]) - resnumber(res[i]) > 1
-            append!(seq, [AA_Gap for _ in 1:(resnumber(res[i+1]) - resnumber(res[i]) - 1)])
+            append!(seq, [Bio.Seq.AA_Gap for _ in 1:(resnumber(res[i+1]) - resnumber(res[i]) - 1)])
         end
     end
-    return AminoAcidSequence(seq)
+    return Bio.Seq.AminoAcidSequence(seq)
 end
 
 

--- a/src/tools/blast/BLAST.jl
+++ b/src/tools/blast/BLAST.jl
@@ -1,13 +1,14 @@
 module BLAST
 
-export blastn,
-       blastp,
-       readblastXML,
-       BLASTResult
+export
+    blastn,
+    blastp,
+    readblastXML,
+    BLASTResult
 
-using Bio.Seq,
-      Bio.Align,
-      EzXML
+import Bio.Align: AlignedSequence
+import Bio.Seq: BioSequence, DNASequence, AminoAcidSequence
+import EzXML
 
 include("blastcommandline.jl")
 

--- a/src/tools/blast/blastcommandline.jl
+++ b/src/tools/blast/blastcommandline.jl
@@ -27,28 +27,28 @@ readblastXML(results)
 Returns Vector{BLASTResult} with the sequence of the hit, the Alignment with query sequence, bitscore and expect value
 """
 function readblastXML(blastrun::AbstractString; seqtype="nucl")
-    dc = parsexml(blastrun)
-    rt = root(dc)
+    dc = EzXML.parsexml(blastrun)
+    rt = EzXML.root(dc)
     results = BLASTResult[]
     for iteration in find(rt, "/BlastOutput/BlastOutput_iterations/Iteration")
-        queryname = content(findfirst(iteration, "Iteration_query-def"))
+        queryname = EzXML.content(findfirst(iteration, "Iteration_query-def"))
         for hit in find(iteration, "Iteration_hits")
-            if countelements(hit) > 0
-                hitname = content(findfirst(hit, "./Hit/Hit_def"))
+            if EzXML.countelements(hit) > 0
+                hitname = EzXML.content(findfirst(hit, "./Hit/Hit_def"))
                 hsps = findfirst(hit, "./Hit/Hit_hsps")
                 if seqtype == "nucl"
-                    qseq = DNASequence(content(findfirst(hsps, "./Hsp/Hsp_qseq")))
-                    hseq = DNASequence(content(findfirst(hsps, "./Hsp/Hsp_hseq")))
+                    qseq = DNASequence(EzXML.content(findfirst(hsps, "./Hsp/Hsp_qseq")))
+                    hseq = DNASequence(EzXML.content(findfirst(hsps, "./Hsp/Hsp_hseq")))
                 elseif seqtype == "prot"
-                    qseq = AminoAcidSequence(content(findfirst(hsps, "./Hsp/Hsp_qseq")))
-                    hseq = AminoAcidSequence(content(findfirst(hsps, "./Hsp/Hsp_hseq")))
+                    qseq = AminoAcidSequence(EzXML.content(findfirst(hsps, "./Hsp/Hsp_qseq")))
+                    hseq = AminoAcidSequence(EzXML.content(findfirst(hsps, "./Hsp/Hsp_hseq")))
                 else
                     throw(error("Please use \"nucl\" or \"prot\" for seqtype"))
                 end
 
                 aln = AlignedSequence(qseq, hseq)
-                bitscore = float(content(findfirst(hsps, "./Hsp/Hsp_bit-score")))
-                expect = float(content(findfirst(hsps, "./Hsp/Hsp_evalue")))
+                bitscore = float(EzXML.content(findfirst(hsps, "./Hsp/Hsp_bit-score")))
+                expect = float(EzXML.content(findfirst(hsps, "./Hsp/Hsp_evalue")))
                 push!(results, BLASTResult(bitscore, expect, queryname, hitname, hseq, aln))
             end
         end

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -8,15 +8,14 @@
 
 module Windows
 
-using Bio.Seq
-
-export eachwindow,
+export
+    eachwindow,
     EachWindowIterator,
     missed
 
+import Bio
 
-
-typealias ArrayOrStringOrSeq Union{AbstractArray, AbstractString, BioSequence}
+typealias ArrayOrStringOrSeq Union{AbstractArray, AbstractString, Bio.Seq.BioSequence}
 
 """
 An iterator which moves across a container, as a sliding window.


### PR DESCRIPTION
The larger our package is, the harder it is to identify names imported from other packages. The reason is mainly because the `using` syntax hides the origin of names and we (at least I) do not have good memory enough to remember all unqualified names.

This pull request will fix the problem by removing `using` used under the `src` directory. The rules are:
1. Do not use `using` to import names from other modules.
2. Use `import` to use other modules.
3. Import names from other modules only when the names are used repeatedly.
4. Use `imoprtall Bio` to import and extend methods shared among submodules of `Bio`.

Currently, I fixed `Bio.Seq`, `Bio.Align`, and `Bio.Intervals` only. I'm going to tidy up other modules if you agree with me.