### PR TITLE
require ColorTypes.jl instead of Colors.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.5
 Automa 0.1
 BGZFStreams 0.1
 BufferedStreams 0.2
-Colors
+ColorTypes 0.2
 Combinatorics
 Distributions
 EzXML 0.2

--- a/src/intervals/Intervals.jl
+++ b/src/intervals/Intervals.jl
@@ -43,9 +43,9 @@ import ..Ragel: tryread!
 export tryread!
 
 importall Bio
+import ColorTypes: RGB
 using
     BufferedStreams,
-    Colors,
     IntervalTrees,
     Libz,
     Bio.Ragel,


### PR DESCRIPTION
Because `RGB` is actually defined in ColorTypes.jl.