### PR TITLE
replace Pkg.dir calls with joinpath(dirname(...))

### DIFF
--- a/src/align/submat.jl
+++ b/src/align/submat.jl
@@ -186,8 +186,7 @@ end
 # --------------------------------
 
 function load_submat{T}(::Type{T}, name)
-    submatfile = Pkg.dir("Bio", "src", "align", "data", "submat", name)
-    return parse_ncbi_submat(T, submatfile)
+    return parse_ncbi_submat(T, joinpath(dirname(@__FILE__), "data", "submat", name))
 end
 
 function parse_ncbi_submat{T}(::Type{T}, filepath)

--- a/test/TestFunctions.jl
+++ b/test/TestFunctions.jl
@@ -12,7 +12,7 @@ export get_bio_fmt_specimens,
 
 
 function get_bio_fmt_specimens()
-    path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
+    path = joinpath(dirname(@__FILE__), "BioFmtSpecimens")
     if !isdir(path)
         run(`git clone --depth 1 https://github.com/BioJulia/BioFmtSpecimens.git $(path)`)
     end

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1004,7 +1004,7 @@ end
     end
 
     @testset "SAM" begin
-        samdir = Pkg.dir("Bio", "test", "BioFmtSpecimens", "SAM")
+        samdir = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "SAM")
 
         @testset "SAMHeader" begin
             h = SAMHeader()
@@ -1134,7 +1134,7 @@ end
     end
 
     @testset "BAM" begin
-        bamdir = Pkg.dir("Bio", "test", "BioFmtSpecimens", "BAM")
+        bamdir = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "BAM")
 
         @testset "Record" begin
             rec = BAMRecord()

--- a/test/intervals/runtests.jl
+++ b/test/intervals/runtests.jl
@@ -431,7 +431,7 @@ end
             return expected_entries == read_entries
         end
 
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "BED")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "BED")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             valid = get(specimen, "valid", true)
             if valid
@@ -531,7 +531,7 @@ end
             return true
         end
 
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "GFF3")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "GFF3")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             valid = get(specimen, "valid", true)
             if valid
@@ -612,7 +612,7 @@ end
 
 @testset "BigBed" begin
     @testset "BED → BigBed → BED round-trip" begin
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "BED")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "BED")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             if !get(specimen, "valid", true)
                 continue

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -2982,7 +2982,7 @@ end
         end
 
         get_bio_fmt_specimens()
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "FASTA")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "FASTA")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             tags = specimen["tags"]
             valid = get(specimen, "valid", true)
@@ -3019,8 +3019,7 @@ end
         end
 
         @testset "genomic sequence" begin
-            path = Pkg.dir("Bio", "test", "BioFmtSpecimens",
-                           "FASTA", "genomic-seq.fasta")
+            path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "FASTA", "genomic-seq.fasta")
             dnaseq = open(first, FASTAReader{DNASequence}, path).seq
             refseq = open(first, FASTAReader{ReferenceSequence}, path).seq
             @test dnaseq == refseq
@@ -3179,7 +3178,7 @@ end
         end
 
         get_bio_fmt_specimens()
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "FASTQ")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "FASTQ")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             tags = get(specimen, "tags", "")
             valid = get(specimen, "valid", true)
@@ -3305,7 +3304,7 @@ end
         end
 
         get_bio_fmt_specimens()
-        path = Pkg.dir("Bio", "test", "BioFmtSpecimens", "2bit")
+        path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "2bit")
         for specimen in YAML.load_file(joinpath(path, "index.yml"))
             valid = get(specimen, "valid", true)
             filepath = joinpath(path, specimen["filename"])

--- a/test/structure/runtests.jl
+++ b/test/structure/runtests.jl
@@ -16,7 +16,7 @@ get_bio_fmt_specimens()
 
 # Access a PDB file in BioFmtSpecimens
 function pdbfilepath(filename::AbstractString)
-    return Pkg.dir("Bio", "test", "BioFmtSpecimens", "PDB", filename)
+    return joinpath(dirname(@__FILE__, "..", "BioFmtSpecimens", "PDB", filename))
 end
 
 

--- a/test/structure/runtests.jl
+++ b/test/structure/runtests.jl
@@ -16,7 +16,7 @@ get_bio_fmt_specimens()
 
 # Access a PDB file in BioFmtSpecimens
 function pdbfilepath(filename::AbstractString)
-    return joinpath(dirname(@__FILE__, "..", "BioFmtSpecimens", "PDB", filename))
+    return joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "PDB", filename)
 end
 
 

--- a/test/tools/runtests.jl
+++ b/test/tools/runtests.jl
@@ -7,7 +7,7 @@ using Bio.Seq,
       TestFunctions
 
 get_bio_fmt_specimens()
-path = Pkg.dir("Bio", "test", "BioFmtSpecimens")
+path = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens")
 
 if !is_windows()  # temporarily disable the BLAST tests on Windows (issue: #197)
 

--- a/test/util/labelledmatrix.jl
+++ b/test/util/labelledmatrix.jl
@@ -102,14 +102,14 @@ using Bio.Util
     end
 
     @testset "files" for (fname, expected) in file_matricies
-        fname = Pkg.dir("Bio", "test", "BioFmtSpecimens", "LSM", fname)
+        fname = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "LSM", fname)
         m, l = readlsm(fname)
         @test m == expected
         @test l == ["A", "B", "C"]
     end
 
     @testset "subst_matrices" for (fname, labels) in subst_matricies
-        fname = Pkg.dir("Bio", "test", "BioFmtSpecimens", "LSM", fname)
+        fname = joinpath(dirname(@__FILE__), "..", "BioFmtSpecimens", "LSM", fname)
         N = length(labels)
         m, l = readlsm(Int64, fname)
         @test size(m) == (N, N)
@@ -118,7 +118,7 @@ using Bio.Util
 
     @testset "all_subst_matrices" for fname in all_subst_matrices
         # Check that we can parse all matrices under the alignm module
-        fname = Pkg.dir("Bio", "src", "align", "data", "submat", fname)
+        fname = joinpath(dirname(@__FILE__), "..", "..", "src", "align", "data", "submat", fname)
         m, l = readlsm(Int64, fname)
         @test eltype(m) === Int64
     end


### PR DESCRIPTION
`Pkg.dir` won't point to the correct path when the package is installed in a non-standard location.