### PR TITLE
WIP: masked sequence

### DIFF
--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -154,7 +154,10 @@ export
     demultiplex,
     seqmatrix,
     majorityvote,
-    tryread!
+    tryread!,
+    MaskedSequence,
+    mask,
+    ismasked
 
 import Automa
 import Automa.RegExp: @re_str
@@ -197,6 +200,7 @@ include("randseq.jl")
 include("kmer.jl")
 include("nmask.jl")
 include("refseq.jl")
+include("masked.jl")
 include("eachkmer.jl")
 include("composition.jl")
 include("geneticcode.jl")

--- a/src/seq/masked.jl
+++ b/src/seq/masked.jl
@@ -1,0 +1,49 @@
+# Masked Sequence
+# ===============
+
+"""
+Masked sequence data structure.
+"""
+immutable MaskedSequence{S<:Sequence,M<:AbstractVector{Bool}} <: Sequence
+    seq::S
+    mask::M
+
+    function MaskedSequence(seq::Sequence, mask::AbstractVector{Bool})
+        if length(seq) != length(mask)
+            throw(ArgumentError("mask length doesn't match"))
+        end
+        # create a subsequence
+        seq = seq[1:end]
+        return new(seq, mask)
+    end
+end
+
+function MaskedSequence(seq::Sequence, mask::AbstractVector{Bool})
+    return MaskedSequence{typeof(seq),typeof(mask)}(seq, mask)
+end
+
+function mask(p::Function, seq::Sequence)
+    mask = falses(length(seq))
+    for (i, x) in enumerate(seq)
+        if p(x)
+            mask[i] = true
+        end
+    end
+    return MaskedSequence(seq, mask)
+end
+
+function ismasked(seq::MaskedSequence, i::Integer)
+    return seq.mask[i]
+end
+
+function Base.length(seq::MaskedSequence)
+    return length(seq.seq)
+end
+
+function Base.eltype(seq::MaskedSequence)
+    return eltype(seq.seq)
+end
+
+function inbounds_getindex(seq::MaskedSequence, i::Integer)
+    return inbounds_getindex(seq.seq, i)
+end

--- a/src/seq/search/exact.jl
+++ b/src/seq/search/exact.jl
@@ -178,10 +178,10 @@ function quicksearch(query, seq, start, stop)
     end
 
     while s ≤ stop′
-        if iscompatible(pat[m], seq[s+m])
+        if iscompatible(pat[m], seq[s+m]) && !ismasked(seq, s+m)
             i = m - 1
             while i > 0
-                if !iscompatible(pat[i], seq[s+i])
+                if !(iscompatible(pat[i], seq[s+i]) && !ismasked(seq, s+i))
                     break
                 end
                 i -= 1
@@ -284,10 +284,10 @@ function quickrsearch(seq, query, start, stop)
     end
 
     while s ≥ stop′
-        if iscompatible(pat[1], seq[s+1])
+        if iscompatible(pat[1], seq[s+1]) && !ismasked(seq, s+1)
             i = 2
             while i < m + 1
-                if !iscompatible(pat[i], seq[s+i])
+                if !(iscompatible(pat[i], seq[s+i]) && !ismasked(seq, s+i))
                     break
                 end
                 i += 1

--- a/src/seq/sequence.jl
+++ b/src/seq/sequence.jl
@@ -41,6 +41,11 @@ end
     return inbounds_getindex(seq, i)
 end
 
+# A sequences is not masked by default.
+function ismasked(seq::Bio.Seq.Sequence, i::Integer)
+    return false
+end
+
 @inline function Base.start(seq::Sequence)
     return 1
 end


### PR DESCRIPTION
This is what I mentioned in https://gitter.im/BioJulia/Bio.jl?at=589a5affde504908229d2b84. We can mask specific regions of a sequence by wrapping a sequence by `MaskedSequence`. For example, if you'd like to mask 'N' regions, you call `mask(x -> x == DNA_N, seq)` and create a masked sequence.

- [ ] Support approximate search and regular expression search.
- [ ] Tests.
- [ ] Docs.