### PR TITLE
Fix to documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -52,7 +52,7 @@ pages:
           - Nucleic acid k-mers: man/seq/sequences/kmer.md
       - Searching: man/seq/search.md
       - Sequence Records: man/seq/seqrecords.md
-      - Demultiplexing: man/seq/demultiplexer.jl
+      - Demultiplexing: man/seq/demultiplexer.md
   - Alignments: man/alignments.md
   - Intervals: man/intervals.md
   - Genetic Variation: man/var.md


### PR DESCRIPTION
This is a simple change to an error which is preventing the update of our online documentation, following re-organization of the `Seq` module.

I'll leave this up for an hour but since it's simple I want to merge it ASAP so as our online manual gets updated.