### PR TITLE
Genomic Distances using MASH

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ Bio.jl v0.5.0 Release Notes
 * Support APIs for Entrez Programming Utilities ([#350]).
 * Support GFF3 file format ([#138]).
 * Sequence names are ordered lexicographically by default ([#291]).
+* Computing genomic distances using the MASH algorithm is introduced ([#415]).
 * IO APIs are reorganized into submodules:
     * `Bio.Seq.FASTAReader` => `Bio.Seq.FASTA.Reader` ([#413]).
     * `Bio.Intervals.BEDReader` => `Bio.Intervals.BED.Reader` ([#418]).
@@ -23,5 +24,6 @@ Bio.jl v0.5.0 Release Notes
 [#391]: https://github.com/BioJulia/Bio.jl/issues/391
 [#399]: https://github.com/BioJulia/Bio.jl/pull/399
 [#413]: https://github.com/BioJulia/Bio.jl/pull/413
+[#415]: https://github.com/BioJulia/Bio.jl/pull/415
 [#418]: https://github.com/BioJulia/Bio.jl/pull/418
 [#426]: https://github.com/BioJulia/Bio.jl/pull/426

--- a/docs/src/man/var.md
+++ b/docs/src/man/var.md
@@ -228,3 +228,40 @@ julia> genotype(record, 1:2, "GT")
  "1|0"
 
 ```
+
+# MASH Distances
+
+[MASH distances](http://doi.org/10.1186/s13059-016-0997-x), based on MinHash
+sketches of genome sequences can provide rapid genome-scale sequence comparisons
+when sequence distance (not specific mutations) are all that's required.
+
+A MinHash sketch is made by taking the `s` smallest hash values for kmers of
+length `k` for a given sequence. The genome distance for two genomes is then
+essentially the [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index)
+of the minhashes, with some additional modification to account for the size of
+the kmers used.
+
+You can generate a MinHash sketch using the `minhash()` function in `Bio.seq`.
+
+```julia
+using Bio.Seq
+
+seq1 = dna"AAATAAGGCACAACTATGCAT"
+sketch1 = minhash(seq, 5, 10)
+```
+
+Then, if you have MinHash sketches with the same parameters for two sequences,
+you can determine the MASH distance between them.
+
+```julia
+seq2 = dna"AATTAACGCACGGACTGCGGTAAT"
+sketch2 = minhash(seq, 5, 10)
+
+using Bio.Var
+
+mashdistance(sketch1, sketch2)
+```
+
+For more information on what size kmers and what size sketches are appropriate
+for your use-case, see [Odnov et. al.](http://doi.org/10.1186/s13059-016-0997-x)
+in _Genome Biology_. 

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -162,7 +162,9 @@ export
     majorityvote,
     tryread!,
     isfilled,
-    MissingFieldException
+    MissingFieldException,
+    MinHashSketch,
+    minhash
 
 import Automa
 import Automa.RegExp: @re_str
@@ -211,6 +213,7 @@ include("composition.jl")
 include("geneticcode.jl")
 include("seqrecord.jl")
 include("demultiplexer.jl")
+include("minhash.jl")
 
 # Parsing file types
 include("fasta/fasta.jl")

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -213,7 +213,6 @@ include("composition.jl")
 include("geneticcode.jl")
 include("seqrecord.jl")
 include("demultiplexer.jl")
-include("minhash.jl")
 
 # Parsing file types
 include("fasta/fasta.jl")
@@ -224,6 +223,8 @@ include("abif/abif.jl")
 include("search/exact.jl")
 include("search/approx.jl")
 include("search/re.jl")
+
+include("minhash.jl")
 
 include("deprecated.jl")
 

--- a/src/seq/minhash.jl
+++ b/src/seq/minhash.jl
@@ -1,0 +1,102 @@
+# MinHash
+# ========
+#
+# Functions to generate MinHash sketches of biological sequences
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+type MinHashSketch
+    sketch::Vector{UInt64}
+    kmersize::Int
+
+    function MinHashSketch(sketch::Vector, kmersize::Int)
+        length(sketch) > 0 || error("Sketch cannot be empty")
+        kmersize > 0 || error("Kmersize must be greater than 0")
+        new(sketch, kmersize)
+    end
+end
+
+Base.getindex(s::MASHSketch, part) = getindex(s.sketch, part)
+
+Base.length(s::MinHashSketch) = length(s.sketch)
+
+Base.size(s::MinHashSketch) = (length(s), s.kmersize)
+
+Base.start(s::MinHashSketch) = start(s.sketch)
+
+Base.next(s::MinHashSketch, state) = next(s.sketch, state)
+
+Base.done(s::MinHashSketch, state) = done(s.sketch, state)
+
+function Base.:(==)(a::MASHSketch, b::MASHSketch)
+    a.kmersize == b.kmersize && a.sketch == b.sketch
+end
+
+
+function revcomphash(kmer::Kmer)
+    k = minimum((kmer, reverse_complement(kmer)))
+    return hash(k)
+end
+
+
+function kmerminhash(seq::BioSequence, kmerset, kmerhashes::Vector{UInt64}, k::Int, s::Int)
+    typeof(kmerset) <: Set || typeof(kmerset) <: SortedSet || error("Kmerset must be a `Set` or `SortedSet`")
+    length(kmerhashes) <= s || error("Kmerhashes cannot be larger than the set size")
+
+    for kmer in each(DNAKmer{k}, seq)
+        if length(kmerhashes) == 0
+            if length(kmerset) < s
+                push!(kmerset, revcomphash(kmer[2]))
+            elseif length(kmerset) == s
+                kmerset = SortedSet(kmerset)
+                for i in kmerset
+                    push!(kmerhashes, pop!(kmerset))
+                end
+            end
+        end
+
+        if length(kmerhashes) == s
+            h = revcomphash(kmer[2])
+            if h < kmerhashes[end]
+                i = searchsortedlast(kmerhashes, h)
+                if i == 0 && i != kmerhashes[1]
+                    pop!(kmerhashes)
+                    unshift!(kmerhashes, h)
+                elseif h != kmerhashes[i]
+                    pop!(kmerhashes)
+                    insert!(kmerhashes, i+1, h)
+                end
+            end
+        end
+
+    end
+    return (kmerset, kmerhashes)
+end
+
+
+function minhash(seq::BioSequence, k::Int, s::Int)
+    kmerset = Set{UInt64}()
+    kmerhashes = Vector{UInt64}()
+    kmerset, kmerhashes = kmerminhash(seq, kmerset, kmerhashes, k, s)
+    return MinHashSketch(kmerhashes, k)
+end
+
+function minhash{T<:BioSequence}(seqs::Vector{T}, k::Int, s::Int)
+    kmerset = Set{UInt64}()
+    kmerhashes = Vector{UInt64}()
+
+    for seq in seqs
+        kmerset, kmerhashes = kmerminhash(seq, kmerset, kmerhashes, k, s)
+    end
+    return MinHashSketch(kmerhashes, k)
+end
+
+function minhash{T<:BioSequence}(seqs::FASTAReader{T}, k::Int, s::Int)
+    kmerset = Set{UInt64}()
+    kmerhashes = Vector{UInt64}()
+    for seq in seqs
+        kmerset, kmerhashes = kmerminhash(seq.seq, kmerset, kmerhashes, k, s)
+    end
+    return MinHashSketch(kmerhashes, k)
+end

--- a/src/seq/minhash.jl
+++ b/src/seq/minhash.jl
@@ -25,14 +25,14 @@ type MinHashSketch
     end
 end
 
-Base.getindex(s::MASHSketch, part) = getindex(s.sketch, part)
+Base.getindex(s::MinHashSketch, part) = getindex(s.sketch, part)
 Base.length(s::MinHashSketch) = length(s.sketch)
 Base.size(s::MinHashSketch) = (length(s), s.kmersize)
 Base.start(s::MinHashSketch) = start(s.sketch)
 Base.next(s::MinHashSketch, state) = next(s.sketch, state)
 Base.done(s::MinHashSketch, state) = done(s.sketch, state)
 
-function Base.:(==)(a::MASHSketch, b::MASHSketch)
+function Base.:(==)(a::MinHashSketch, b::MinHashSketch)
     a.kmersize == b.kmersize && a.sketch == b.sketch
 end
 

--- a/src/seq/minhash.jl
+++ b/src/seq/minhash.jl
@@ -18,12 +18,12 @@ hashes for kmers of a given length. The type contains two parameters:
 """
 immutable MinHashSketch
     sketch::Vector{UInt64}
-    kmersize::Int
+    kmersize::Integer
 
-    function MinHashSketch(sketch::Vector, kmersize::Int)
+    function MinHashSketch(sketch::Vector, kmersize::Integer)
         length(sketch) > 0 || error("Sketch cannot be empty")
         kmersize > 0 || error("Kmersize must be greater than 0")
-        new(sketch, kmersize)
+        return new(sketch, kmersize)
     end
 end
 
@@ -34,18 +34,18 @@ Base.next(s::MinHashSketch, state) = next(s.sketch, state)
 Base.done(s::MinHashSketch, state) = done(s.sketch, state)
 
 function Base.:(==)(a::MinHashSketch, b::MinHashSketch)
-    a.kmersize == b.kmersize && a.sketch == b.sketch
+    return a.kmersize == b.kmersize && a.sketch == b.sketch
 end
 
 # A seqence and its reverse complement should be the same, so take the smallest
 # hash of a seq or its reverse complement.
 function revcomphash(kmer::Kmer)
-    k = min((kmer, reverse_complement(kmer)))
+    k = min(kmer, reverse_complement(kmer))
     return hash(k)
 end
 
 
-function kmerminhash{k}(::Type{DNAKmer{k}}, seq::BioSequence, s::Int)
+function kmerminhash{k}(::Type{DNAKmer{k}}, seq::BioSequence, s::Integer)
     # generate first `s` kmers
     kmerhashes = UInt64[]
     iter = each(DNAKmer{k}, seq)
@@ -82,16 +82,16 @@ function kmerminhash{k}(::Type{DNAKmer{k}}, seq::BioSequence, s::Int)
 end
 
 """
-    minhash(seq, k::Int, s::Int)
+    minhash(seq, k::Integer, s::Integer)
 
 Generate a MinHash sketch of size `s` for kmers of length `k`.
 """
-function minhash(seq::BioSequence, k::Int, s::Int)
+function minhash(seq::BioSequence, k::Integer, s::Integer)
     kmerhashes = mykmerminhash(DNAKmer{k}, seq, s)
     return MinHashSketch(kmerhashes, k)
 end
 
-function minhash{T<:BioSequence}(seqs::Vector{T}, k::Int, s::Int)
+function minhash{T<:BioSequence}(seqs::Vector{T}, k::Integer, s::Integer)
     kmerset = Set{UInt64}()
     kmerhashes = Vector{UInt64}()
 
@@ -103,7 +103,7 @@ function minhash{T<:BioSequence}(seqs::Vector{T}, k::Int, s::Int)
     return MinHashSketch(kmerhashes, k)
 end
 
-function minhash{T<:BioSequence}(seqs::FASTA.Reader{T}, k::Int, s::Int)
+function minhash{T<:BioSequence}(seqs::FASTA.Reader{T}, k::Integer, s::Integer)
     kmerset = Set{UInt64}()
     kmerhashes = Vector{UInt64}()
     for seq in seqs

--- a/src/seq/minhash.jl
+++ b/src/seq/minhash.jl
@@ -5,6 +5,8 @@
 #
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+using DataStructures: SortedSet
+
 """
 MinHash Sketch type
 

--- a/src/seq/minhash.jl
+++ b/src/seq/minhash.jl
@@ -100,10 +100,10 @@ function minhash{T<:BioSequence}(seqs::Vector{T}, k::Integer, s::Integer)
     return MinHashSketch(kmerhashes, k)
 end
 
-function minhash{T<:BioSequence}(seqs::FASTAReader{T}, k::Integer, s::Integer)
+function minhash(seqs::FASTA.Reader, k::Integer, s::Integer)
     kmerhashes = UInt64[]
     for seq in seqs
-        kmerminhash!(DNAKmer{k}, seq.seq, s, kmerhashes)
+        kmerminhash!(DNAKmer{k}, sequence(seq), s, kmerhashes)
     end
 
     length(kmerhashes) < s && error("failed to generate enough hashes")

--- a/src/var/Var.jl
+++ b/src/var/Var.jl
@@ -70,7 +70,8 @@ export
     hasformat,
     genotype,
 
-    MissingFieldException
+    MissingFieldException,
+    mashdistance
 
 # Bio.@reexport import Bio: isfilled, leftposition
 
@@ -78,5 +79,6 @@ include("site_counting/site_counting.jl")
 #include("distances.jl")
 include("vcf/vcf.jl")
 include("bcf/bcf.jl")
+include("mash.jl")
 
 end # module Var

--- a/src/var/mash.jl
+++ b/src/var/mash.jl
@@ -1,7 +1,7 @@
 # MinHash
 # ========
 #
-# Functions to MASH distance for MinHash sketches
+# Functions to get MASH distance for MinHash sketches
 #
 # see DOI: 10.1186/s13059-016-0997-x
 #

--- a/src/var/mash.jl
+++ b/src/var/mash.jl
@@ -1,0 +1,34 @@
+# MinHash
+# ========
+#
+# Functions to MASH distance for MinHash sketches
+#
+# see DOI: 10.1186/s13059-016-0997-x
+#
+# This file is a part of BioJulia.
+# License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+function jaccarddistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
+    d = length(setdiff(sketch1.sketch, sketch2.sketch))
+    l = length(sketch1)
+    return (l-d) / (l+d)
+end
+
+function mashdistance(k::Int, j::Float64)
+    return -1/k * log(2j / (1+j))
+end
+
+"""
+    mashdistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
+
+Determines the MASH distance between two MinHash sketches. Requires that each
+sketch is the same size, using kmers of the same length
+"""
+function mashdistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
+    sketch1.kmersize == sketch2.kmersize || error("sketches must have same kmer length")
+    length(sketch1) == length(sketch2) || error("sketches must be the same size")
+
+    j = jaccarddistance(sketch1, sketch2)
+    k = sketch1.kmersize
+    return mashdistance(k, j)
+end

--- a/src/var/mash.jl
+++ b/src/var/mash.jl
@@ -23,11 +23,11 @@ function jaccarddistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
             i += 1
             j += 1
         elseif sketch1.sketch[i] < sketch2.sketch[j]
-            while sketch1.sketch[i] < sketch2.sketch[j]
+            while i <= sketchlen && sketch1.sketch[i] < sketch2.sketch[j]
                 i += 1
             end
         elseif sketch2.sketch[j] < sketch1.sketch[i]
-            while sketch2.sketch[j] < sketch1.sketch[i]
+            while j <= sketchlen && sketch2.sketch[j] < sketch1.sketch[i]
                 j += 1
             end
         end

--- a/src/var/mash.jl
+++ b/src/var/mash.jl
@@ -9,9 +9,30 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 function jaccarddistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
-    d = length(setdiff(sketch1.sketch, sketch2.sketch))
-    l = length(sketch1)
-    return (l-d) / (l+d)
+    sketch1.kmersize == sketch2.kmersize || error("sketches must have same kmer length")
+    length(sketch1) == length(sketch2) || error("sketches must be the same size")
+
+    matches = 0
+    sketchlen = length(sketch1)
+    i = 1
+    j = 1
+
+    while i <= sketchlen && j <= sketchlen
+        if sketch1.sketch[i] == sketch2.sketch[j]
+            matches += 1
+            i += 1
+            j += 1
+        elseif sketch1.sketch[i] < sketch2.sketch[j]
+            while sketch1.sketch[i] < sketch2.sketch[j]
+                i += 1
+            end
+        elseif sketch2.sketch[j] < sketch1.sketch[i]
+            while sketch2.sketch[j] < sketch1.sketch[i]
+                j += 1
+            end
+        end
+    end
+    matches == sketchlen ? (return 1.0) : return matches / (2 * sketchlen - matches)
 end
 
 function mashdistance(k::Int, j::Float64)
@@ -25,9 +46,6 @@ Determines the MASH distance between two MinHash sketches. Requires that each
 sketch is the same size, using kmers of the same length
 """
 function mashdistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
-    sketch1.kmersize == sketch2.kmersize || error("sketches must have same kmer length")
-    length(sketch1) == length(sketch2) || error("sketches must be the same size")
-
     j = jaccarddistance(sketch1, sketch2)
     k = sketch1.kmersize
     return mashdistance(k, j)

--- a/src/var/mash.jl
+++ b/src/var/mash.jl
@@ -32,10 +32,15 @@ function jaccarddistance(sketch1::MinHashSketch, sketch2::MinHashSketch)
             end
         end
     end
-    matches == sketchlen ? (return 1.0) : return matches / (2 * sketchlen - matches)
+
+    if matches == sketchlen
+        return 1.0
+    else
+        return matches / (2 * sketchlen - matches)
+    end
 end
 
-function mashdistance(k::Int, j::Float64)
+function mashdistance(k::Integer, j::Float64)
     return -1/k * log(2j / (1+j))
 end
 

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -1038,11 +1038,10 @@ end
         @test hash(aa"MTTQAPMFTQPLQ"[5:10]) === hash(aa"APMFTQ")
 
         @testset "MinHash" begin
-            seq = random_dna_kmer(1000)
+            seq = DNASequence(random_dna(1000))
             h = minhash(seq, 10, 100)
 
             @test length(h) == 100
-            @test size(h) == (100, 10)
             @test h == minhash(seq, 10, 100)
 
             @test_throws BoundsError h[101]

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -1036,6 +1036,18 @@ end
         @test hash(rna"AAUUAA"[3:5]) === hash(rna"UUA")
         @test hash(aa"MTTQAPMFTQPLQ") === hash(aa"MTTQAPMFTQPLQ")
         @test hash(aa"MTTQAPMFTQPLQ"[5:10]) === hash(aa"APMFTQ")
+
+        @testset "MinHash" begin
+            seq = random_dna_kmer(1000)
+            h = minhash(seq, 10, 100)
+
+            @test length(h) == 100
+            @test size(h) == (100, 10)
+            @test h == minhash(seq, 10, 100)
+
+            @test_throws BoundsError h[101]
+        end
+
     end
 
     @testset "Length" begin

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -114,7 +114,11 @@ end
 
             a = minhash(dnas[1], 4, 3)
             b = minhash(dnas[2], 4, 3)
-            @test_approx_eq_eps mashdistance(a, b) 0.2745 1e-3
+            @test_approx_eq_eps mashdistance(a, b) 0.2745*1e-3
+            @test mashdistance(a, a) == 0
+            @test a.sketch == sort(a.sketch)
+
+
         end
 
         @testset "Windowed methods" begin

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -114,7 +114,7 @@ end
 
             a = minhash(dnas[1], 4, 3)
             b = minhash(dnas[2], 4, 3)
-            @test_approx_eq_eps mashdistance(a, b) 0.2745*1e-3
+            @test_approx_eq_eps mashdistance(a, b) 0.2745 1e-3
             @test mashdistance(a, a) == 0
             @test a.sketch == sort(a.sketch)
 

--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -111,6 +111,10 @@ end
                 @test count_sites(Conserved, i) == (PWM{Int, false}([0 6 6 5; 6 0 7 7; 6 7 0 6; 5 7 6 0]), ambigs)
                 @test count_sites(Mutated, i) == (PWM{Int, false}([0 1 1 2; 1 0 0 1; 1 0 0 1; 2 1 1 0]), ambigs)
             end
+
+            a = minhash(dnas[1], 4, 3)
+            b = minhash(dnas[2], 4, 3)
+            @test_approx_eq_eps mashdistance(a, b) 0.2745 1e-3
         end
 
         @testset "Windowed methods" begin


### PR DESCRIPTION
This is a PR for an idea [I brought up months ago in gitter](https://gitter.im/BioJulia/Bio.jl?at=584c96b1c29531ac5d4917e2). I'd like to add a small module to calculate the [MASH distance](https://genomebiology.biomedcentral.com/articles/10.1186/s13059-016-0997-x) between two genomes. 

Briefly, the theory is that you generate a hash for all kmers of size `k`, but only store a "bottom sketch" of a particular genome of size `s` - that is the `s` smallest hashes. If you store the hashes in sorted order, you only need to check if each subsequent hash is larger than a single value, so this is quite fast. The genome distance for two genomes is then essentially the [Jaccard index](https://en.wikipedia.org/wiki/Jaccard_index) of the minhashes, with some additional modification to account for the size of the kmers used. 

I have [an implementation](https://github.com/kescobo/MashTun/blob/master/src/MashTun.jl) that I've validated and is quite fast - from two FASTA files of ~5 Mbp each to MASH distance takes ~2 sec on my 3 year old macbook pro. Most of this time is spent generating the sketch, but once a sketch is made, the comparison between two genomes takes less than a millisecond (so adding additional genomes scales very well).

I'm ready to start adding documentation and tests, but thought I should open a PR and get some guidance on where this fits in Bio.jl, and if I should add anything else to the module.

### Minhash
- [x] Implement MinHash in Seq
- [x] MinHash Tests
- [x] Documentation

### MASH Distance
- [x] Implement MASH distance in Var
- [x] MASH Tests
- [x] Documentation

## Still to-do
- [x]  fix CI errors