### PR TITLE
Syntax changes: julia v0.6 Prep.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
   - osx
 julia:
   - 0.5
+  - 0.6
   - nightly
 matrix:
   allow_failures:

--- a/docs/src/man/alignments.md
+++ b/docs/src/man/alignments.md
@@ -76,7 +76,7 @@ julia> Alignment([
 
 Alignment operations follow closely from those used in the [SAM/BAM
 format](https://samtools.github.io/hts-specs/SAMv1.pdf) and are stored in the
-`Operation` bitstype.
+`Operation` primitive type.
 
 | Operation            | Operation Type     | Description                                                                     |
 | :------------------- | :----------------- | :------------------------------------------------------------------------------ |

--- a/src/IO.jl
+++ b/src/IO.jl
@@ -13,12 +13,12 @@ Abstract file format type.
 
 See `subtypes(FileFormat)` for all available file formats.
 """
-abstract FileFormat
+abstract type FileFormat end
 
 """
 Abstract formatted input/output type.
 """
-abstract AbstractFormattedIO
+abstract type AbstractFormattedIO end
 
 """
     stream(io::AbstractFormattedIO)
@@ -50,7 +50,7 @@ Abstract data reader type.
 
 See `subtypes(AbstractReader)` for all available data readers.
 """
-abstract AbstractReader <: AbstractFormattedIO
+abstract type AbstractReader <: AbstractFormattedIO end
 
 Base.iteratorsize{T<:AbstractReader}(::Type{T}) = Base.SizeUnknown()
 
@@ -64,7 +64,7 @@ Abstract data writer type.
 
 See `subtypes(AbstractWriter)` for all available data writers.
 """
-abstract AbstractWriter <: AbstractFormattedIO
+abstract type AbstractWriter <: AbstractFormattedIO end
 
 function Base.open{T<:AbstractWriter}(::Type{T}, filepath::AbstractString, args...; kwargs...)
     i = findfirst(kwarg -> kwarg[1] == :append, kwargs)

--- a/src/align/models.jl
+++ b/src/align/models.jl
@@ -13,7 +13,7 @@
 """
 Supertype of score model.
 """
-abstract AbstractScoreModel{T<:Real}
+abstract type AbstractScoreModel{T<:Real} end
 
 """
     AffineGapScoreModel(submat, gap_open, gap_extend)
@@ -123,7 +123,7 @@ end
 """
 Supertype of cost model.
 """
-abstract AbstractCostModel{T}
+abstract type AbstractCostModel{T} end
 
 """
     CostModel(submat, insertion, deletion)

--- a/src/align/operations.jl
+++ b/src/align/operations.jl
@@ -7,7 +7,7 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 # An alignment operation type
-bitstype 8 Operation
+primitive type Operation 8 end
 
 
 # Conversion to and from integers

--- a/src/align/pairwise/algorithms/common.jl
+++ b/src/align/pairwise/algorithms/common.jl
@@ -16,7 +16,7 @@ end
 # ----------
 
 # trace type for pairwise alignment
-typealias Trace UInt8
+const Trace = UInt8
 
 # trace bitmap
 const TRACE_NONE   = 0b00000

--- a/src/align/submat.jl
+++ b/src/align/submat.jl
@@ -13,7 +13,7 @@ The required method:
 
 * `Base.getindex(submat, x, y)`: substitution score/cost from `x` to `y`
 """
-abstract AbstractSubstitutionMatrix{S<:Real}
+abstract type AbstractSubstitutionMatrix{S<:Real} end
 
 """
 Substitution matrix.

--- a/src/align/types.jl
+++ b/src/align/types.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-abstract AbstractAlignment
+abstract type AbstractAlignment end
 
 
 # Alignments

--- a/src/intervals/bed/bed.jl
+++ b/src/intervals/bed/bed.jl
@@ -69,7 +69,7 @@ function Base.:(==)(a::BEDMetadata, b::BEDMetadata)
 end
 
 "An `Interval` with associated metadata from a BED file"
-typealias BEDInterval Interval{BEDMetadata}
+const BEDInterval = Interval{BEDMetadata}
 
 include("reader.jl")
 include("parser.jl")

--- a/src/intervals/index/bgzfindex.jl
+++ b/src/intervals/index/bgzfindex.jl
@@ -10,10 +10,10 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 # binning index
-typealias BinIndex Dict{UInt32,Vector{Chunk}}
+const BinIndex = Dict{UInt32,Vector{Chunk}}
 
 # linear index
-typealias LinearIndex Vector{VirtualOffset}
+const LinearIndex = Vector{VirtualOffset}
 
 # Metadata providing a summary of the number of mappend/unmapped reads.
 type PseudoBin

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -208,7 +208,7 @@ Interval{T} objects in sorted order.
 """
 abstract type IntervalStream{T} end
 
-typealias IntervalStreamOrArray{T} Union{Vector{Interval{T}},IntervalStream{T},Bio.IO.AbstractReader}
+const IntervalStreamOrArray{T} = Union{Vector{Interval{T}},IntervalStream{T},Bio.IO.AbstractReader}
 
 function metadatatype{T}(::IntervalStream{T})
     return T

--- a/src/intervals/interval.jl
+++ b/src/intervals/interval.jl
@@ -206,7 +206,7 @@ end
 A type deriving `IntervalStream{T}` must be iterable and produce
 Interval{T} objects in sorted order.
 """
-abstract IntervalStream{T}
+abstract type IntervalStream{T} end
 
 typealias IntervalStreamOrArray{T} Union{Vector{Interval{T}},IntervalStream{T},Bio.IO.AbstractReader}
 

--- a/src/intervals/intervalcollection.jl
+++ b/src/intervals/intervalcollection.jl
@@ -32,7 +32,7 @@
 #       ordered iteration.             ...
 #
 
-typealias IntervalCollectionTree{T} IntervalTrees.IntervalTree{Int64,Interval{T}}
+const IntervalCollectionTree{T} = IntervalTrees.IntervalTree{Int64,Interval{T}}
 
 type IntervalCollection{T} <: IntervalStream{T}
     # Sequence name mapped to IntervalTree, which in turn maps intervals to
@@ -136,7 +136,7 @@ Base.length(ic::IntervalCollection) = ic.length
 # Iterators
 # --------
 
-typealias IntervalCollectionTreeIteratorState{T} IntervalTrees.IntervalBTreeIteratorState{Int64,Interval{T},64}
+const IntervalCollectionTreeIteratorState{T} = IntervalTrees.IntervalBTreeIteratorState{Int64,Interval{T},64}
 
 immutable IntervalCollectionIteratorState{T}
     i::Int # index into ordered_trees

--- a/src/intervals/strand.jl
+++ b/src/intervals/strand.jl
@@ -6,7 +6,7 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-bitstype 8 Strand
+primitive type Strand 8 end
 
 Base.convert(::Type{Strand}, strand::UInt8) = reinterpret(Strand, strand)
 Base.convert(::Type{UInt8}, strand::Strand) = reinterpret(UInt8, strand)

--- a/src/phylo/dating.jl
+++ b/src/phylo/dating.jl
@@ -24,8 +24,8 @@ Types inheriting from DatingEstimate should have the following methods defined:
 
 They may define their own show methods.
 """
-abstract DatingEstimate
-abstract DatingMethod
+abstract type DatingEstimate end
+abstract type DatingMethod end
 
 Base.print(io::IO, de::DatingEstimate) = println(io, "$(lower(de)) ... $(upper(de))")
 Base.show(io::IO, de::DatingEstimate) = println(io, "Coalesence time estimate between two sequences:\nt lies between $(lower(de)) and $(upper(de))")

--- a/src/phylo/metadata.jl
+++ b/src/phylo/metadata.jl
@@ -7,7 +7,7 @@
 #
 # This file is a part of BioJulia. License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-abstract BranchMetaData
+abstract type BranchMetaData end
 
 # Every Metadata type should be immutable, and should have the following
 # methods defined:

--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -15,7 +15,7 @@
 """
 Alphabet of biological characters.
 """
-abstract Alphabet
+abstract type Alphabet end
 
 """
 DNA nucleotide alphabet.

--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -42,7 +42,7 @@ Void alphabet (internal use only).
 """
 immutable VoidAlphabet <: Alphabet end
 
-typealias NucleicAcidAlphabet Union{DNAAlphabet,RNAAlphabet}
+const NucleicAcidAlphabet = Union{DNAAlphabet,RNAAlphabet}
 
 """
 The number of bits to represent the alphabet.

--- a/src/seq/aminoacid.jl
+++ b/src/seq/aminoacid.jl
@@ -7,7 +7,7 @@
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
 "Type representing AminoAcids"
-bitstype 8 AminoAcid
+primitive type AminoAcid 8 end
 
 
 # Conversion from/to integers

--- a/src/seq/bioseq/bioseq.jl
+++ b/src/seq/bioseq/bioseq.jl
@@ -52,10 +52,10 @@ type BioSequence{A<:Alphabet} <: Sequence
     end
 end
 
-typealias DNASequence       BioSequence{DNAAlphabet{4}}
-typealias RNASequence       BioSequence{RNAAlphabet{4}}
-typealias AminoAcidSequence BioSequence{AminoAcidAlphabet}
-typealias CharSequence      BioSequence{CharAlphabet}
+const DNASequence       =  BioSequence{DNAAlphabet{4}}
+const RNASequence       =  BioSequence{RNAAlphabet{4}}
+const AminoAcidSequence =  BioSequence{AminoAcidAlphabet}
+const CharSequence      =  BioSequence{CharAlphabet}
 
 "Gets the alphabet encoding of a given BioSequence."
 alphabet{A}(::Type{BioSequence{A}}) = alphabet(A)

--- a/src/seq/bioseq/randseq.jl
+++ b/src/seq/bioseq/randseq.jl
@@ -9,7 +9,7 @@
 """
 Abstract sequence generator type.
 """
-abstract SequenceGenerator{T}
+abstract type SequenceGenerator{T} end
 
 # Sequence generator of stationary distributions.
 immutable StationaryGenerator{T} <: SequenceGenerator{T}

--- a/src/seq/fasta_old/fasta.jl
+++ b/src/seq/fasta_old/fasta.jl
@@ -28,7 +28,7 @@ end
 
 Create a sequence record for the FASTA file format.
 """
-typealias FASTASeqRecord{S} SeqRecord{S,FASTAMetadata}
+const FASTASeqRecord{S} = SeqRecord{S,FASTAMetadata}
 
 function (::Type{FASTASeqRecord})(name::AbstractString,
                                   seq::Sequence,

--- a/src/seq/fastq/fastq.jl
+++ b/src/seq/fastq/fastq.jl
@@ -38,7 +38,7 @@ end
 
 Create a sequence record for the FASTQ file format.
 """
-typealias FASTQSeqRecord{S} SeqRecord{S,FASTQMetadata}
+const FASTQSeqRecord{S} = SeqRecord{S,FASTQMetadata}
 
 function (::Type{FASTQSeqRecord})(name::AbstractString,
                                   seq::Sequence,

--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -31,10 +31,10 @@
 
 primitive type Kmer{T<:NucleicAcid, K} <: Sequence 64 end
 
-typealias DNAKmer{K} Kmer{DNA, K}
-typealias RNAKmer{K} Kmer{RNA, K}
-typealias DNACodon DNAKmer{3}
-typealias RNACodon RNAKmer{3}
+const DNAKmer{K} = Kmer{DNA, K}
+const RNAKmer{K} = Kmer{RNA, K}
+const DNACodon = DNAKmer{3}
+const RNACodon = RNAKmer{3}
 
 function Kmer{T<:NucleicAcid}(nts::T...)
     return make_kmer(nts)

--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -29,7 +29,7 @@
 #   64-bit: 0b 00 00 … 00 11 00 01 10
 #    4-mer:                T  A  C  G
 
-bitstype 64 Kmer{T<:NucleicAcid, K} <: Sequence
+primitive type Kmer{T<:NucleicAcid, K} <: Sequence 64 end
 
 typealias DNAKmer{K} Kmer{DNA, K}
 typealias RNAKmer{K} Kmer{RNA, K}

--- a/src/seq/nucleicacid.jl
+++ b/src/seq/nucleicacid.jl
@@ -24,8 +24,8 @@
 # bits of a byte.
 
 abstract NucleicAcid
-bitstype 8 DNA <: NucleicAcid
-bitstype 8 RNA <: NucleicAcid
+primitive type DNA <: NucleicAcid 8 end
+primitive type RNA <: NucleicAcid 8 end
 
 
 # Conversion from/to integers

--- a/src/seq/nucleicacid.jl
+++ b/src/seq/nucleicacid.jl
@@ -23,7 +23,7 @@
 # always 0000.  The meaningful four bits are stored in the least significant
 # bits of a byte.
 
-abstract NucleicAcid
+abstract type NucleicAcid end
 primitive type DNA <: NucleicAcid 8 end
 primitive type RNA <: NucleicAcid 8 end
 

--- a/src/seq/search/re.jl
+++ b/src/seq/search/re.jl
@@ -439,7 +439,7 @@ end
 # 0b110 | last      | matches the last of string
 # 0b111 | fork l    | push next and go to l
 
-bitstype 32 Op
+primitive type Op 32 end
 
 const MatchTag = UInt32(0b000) << 29
 const BitsTag  = UInt32(0b001) << 29

--- a/src/seq/sequence.jl
+++ b/src/seq/sequence.jl
@@ -16,7 +16,7 @@ Any subtype `S <: Sequence` should implement the following methods:
 * `inbounds_getindex(seq::S, i::Integer)`: return the element at `i` of `seq`
     without checking bounds
 """
-abstract Sequence
+abstract type Sequence end
 
 # This is useful for obscure reasons. We use SeqRecord{Sequence} for reading
 # sequence in an undetermined alphabet, but a consequence that we need to be

--- a/src/structure/model.jl
+++ b/src/structure/model.jl
@@ -89,14 +89,14 @@ export
 
 
 "A macromolecular structural element."
-abstract StructuralElement
+abstract type StructuralElement end
 
 
 """
 An atom that is part of a macromolecule - either an `Atom` or a
 `DisorderedAtom`.
 """
-abstract AbstractAtom <: StructuralElement
+abstract type AbstractAtom <: StructuralElement end
 
 "An atom that is part of a macromolecule."
 immutable Atom <: AbstractAtom
@@ -122,7 +122,7 @@ end
 A residue (amino acid) or other molecule - either a`Residue` or a
 `DisorderedResidue`.
 """
-abstract AbstractResidue <: StructuralElement
+abstract type AbstractResidue <: StructuralElement end
 
 "A residue (amino acid) or other molecule."
 immutable Residue <: AbstractResidue

--- a/src/util/windows.jl
+++ b/src/util/windows.jl
@@ -17,7 +17,7 @@ export
 
 import Bio
 
-typealias ArrayOrStringOrSeq Union{AbstractArray, AbstractString, Bio.Seq.BioSequence}
+const ArrayOrStringOrSeq = Union{AbstractArray, AbstractString, Bio.Seq.BioSequence}
 
 """
 An iterator which moves across a container, as a sliding window.

--- a/src/var/distances.jl
+++ b/src/var/distances.jl
@@ -10,10 +10,10 @@
 # Types
 # -----
 
-abstract EvolutionaryDistance
-abstract UncorrectedDistance <: EvolutionaryDistance
-abstract CorrectedDistance <: EvolutionaryDistance
-abstract TsTv <: CorrectedDistance
+abstract type EvolutionaryDistance end
+abstract type UncorrectedDistance <: EvolutionaryDistance end
+abstract type CorrectedDistance <: EvolutionaryDistance end
+abstract type TsTv <: CorrectedDistance end
 
 """
 A distance which is the count of the mutations of type T that exist between the

--- a/src/var/mutation_counting.jl
+++ b/src/var/mutation_counting.jl
@@ -14,7 +14,7 @@
 
 # Mutation types
 
-abstract MutationType
+abstract type MutationType end
 
 """
 `AnyMutation` describes a site where two aligned nucleotides are not the

--- a/src/var/site_counting/site_types.jl
+++ b/src/var/site_counting/site_types.jl
@@ -4,8 +4,8 @@
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
 
-abstract Site
-abstract Mutation <: Site
+abstract type Site end
+abstract type Mutation <: Site end
 
 """
 A `Certain` site describes a site where both of two aligned sites are not an


### PR DESCRIPTION
This changes some syntax the new julia v0.6 syntax. This will want to be merged (assuming checks pass for 0.6), when julia 0.6 becomes the stable julia release.