### PR TITLE
Bio.Structure parsing speedup

### DIFF
--- a/src/structure/pdb.jl
+++ b/src/structure/pdb.jl
@@ -111,73 +111,134 @@ end
 # Constructor from PDB ATOM/HETATM line
 AtomRecord(pdb_line::String, line_n::Integer=1) = AtomRecord(
     pdb_line[1] == 'H', # This assumes the line has already been checked as an ATOM/HETATM record
-    parsestrict(pdb_line, 7, 11, Int, "Could not read atom serial number", line_n),
-    parsestrict(pdb_line, 13, 16, String, "Could not read atom name", line_n),
-    parsestrict(pdb_line, 17, 17, Char, "Could not read alt loc identifier", line_n),
-    parsestrict(pdb_line, 18, 20, String, "Could not read residue name", line_n),
-    parsestrict(pdb_line, 22, 22, Char, "Could not read chain ID", line_n),
-    parsestrict(pdb_line, 23, 26, Int, "Could not read residue number", line_n),
-    parsestrict(pdb_line, 27, 27, Char, "Could not read insertion code", line_n),
+    parseserial(pdb_line, line_n),
+    parseatomname(pdb_line, line_n),
+    parsealtloc(pdb_line, line_n),
+    parseresname(pdb_line, line_n),
+    parsechainid(pdb_line, line_n),
+    parseresnumber(pdb_line, line_n),
+    parseinscode(pdb_line, line_n),
     [
-        parsestrict(pdb_line, 31, 38, Float64, "Could not read x coordinate", line_n),
-        parsestrict(pdb_line, 39, 46, Float64, "Could not read y coordinate", line_n),
-        parsestrict(pdb_line, 47, 54, Float64, "Could not read z coordinate", line_n)
+        parsecoordx(pdb_line, line_n),
+        parsecoordy(pdb_line, line_n),
+        parsecoordz(pdb_line, line_n)
     ],
-    parselenient(pdb_line, 55, 60, Float64, 1.0),
-    parselenient(pdb_line, 61, 66, Float64, 0.0),
-    parselenient(pdb_line, 77, 78, String, "  "),
-    parselenient(pdb_line, 79, 80, String, "  ")
+    parseoccupancy(pdb_line),
+    parsetempfac(pdb_line),
+    parseelement(pdb_line),
+    parsecharge(pdb_line)
 )
 
 
-"Parse columns from a line and return the value or throw a `PDBParseError`."
-function parsestrict(line::String,
-                    col_1::Integer,
-                    col_2::Integer,
-                    out_type::Type,
-                    error_message::AbstractString,
-                    line_n::Integer)
+function parseserial(line::String, line_n::Integer=1)
     try
-        return parsevalue(line, col_1, col_2, out_type)
+        return parse(Int, line[7:11])
     catch
-        throw(PDBParseError(error_message, line_n, line))
+        throw(PDBParseError("Could not read atom serial number", line_n, line))
     end
 end
 
-
-"Parse columns from a line and return the value or a default value."
-function parselenient(line::String,
-                    col_1::Integer,
-                    col_2::Integer,
-                    out_type::Type,
-                    default)
+function parseatomname(line::String, line_n::Integer=1)
     try
-        return parsevalue(line, col_1, col_2, out_type)
+        return line[13:16]
     catch
-        return default
+        throw(PDBParseError("Could not read atom name", line_n, line))
     end
 end
 
-
-"Parse columns from a line into a given type."
-function parsevalue(line::String,
-                    col_1::Integer,
-                    col_2::Integer,
-                    out_type::Type)
+function parsealtloc(line::String, line_n::Integer=1)
     try
-        if out_type == Int
-            return parse(Int, line[col_1:col_2])
-        elseif out_type == Float64
-            return parse(Float64, line[col_1:col_2])
-        elseif out_type == String
-            return line[col_1:col_2]
-        elseif out_type == Char
-            return line[col_1]
-        else
-            error()
-        end
+        return line[17]
     catch
-        error("Could not parse to desired type")
+        throw(PDBParseError("Could not read alt loc identifier", line_n, line))
+    end
+end
+
+function parseresname(line::String, line_n::Integer=1)
+    try
+        return line[18:20]
+    catch
+        throw(PDBParseError("Could not read residue name", line_n, line))
+    end
+end
+
+function parsechainid(line::String, line_n::Integer=1)
+    try
+        return line[22]
+    catch
+        throw(PDBParseError("Could not read chain ID", line_n, line))
+    end
+end
+
+function parseresnumber(line::String, line_n::Integer=1)
+    try
+        return parse(Int, line[23:26])
+    catch
+        throw(PDBParseError("Could not read residue number", line_n, line))
+    end
+end
+
+function parseinscode(line::String, line_n::Integer=1)
+    try
+        return line[27]
+    catch
+        throw(PDBParseError("Could not read insertion code", line_n, line))
+    end
+end
+
+function parsecoordx(line::String, line_n::Integer=1)
+    try
+        return parse(Float64, line[31:38])
+    catch
+        throw(PDBParseError("Could not read x coordinate", line_n, line))
+    end
+end
+
+function parsecoordy(line::String, line_n::Integer=1)
+    try
+        return parse(Float64, line[39:46])
+    catch
+        throw(PDBParseError("Could not read y coordinate", line_n, line))
+    end
+end
+
+function parsecoordz(line::String, line_n::Integer=1)
+    try
+        return parse(Float64, line[47:54])
+    catch
+        throw(PDBParseError("Could not read z coordinate", line_n, line))
+    end
+end
+
+function parseoccupancy(line::String)
+    try
+        return parse(Float64, line[55:60])
+    catch
+        return 1.0
+    end
+end
+
+function parsetempfac(line::String)
+    try
+        return parse(Float64, line[61:66])
+    catch
+        return 0.0
+    end
+end
+
+function parseelement(line::String)
+    try
+        return line[77:78]
+    catch
+        return "  "
+    end
+end
+
+function parsecharge(line::String)
+    try
+        return line[79:80]
+    catch
+        return "  "
     end
 end
 

--- a/src/structure/spatial.jl
+++ b/src/structure/spatial.jl
@@ -277,7 +277,7 @@ end
 
 """
 Calculate the contact map for a `StructuralElementOrList`, or between two
-`StructuralElementOrList`s. This is an `BitArray{2}` with `true` where the
+`StructuralElementOrList`s. This is a `BitArray{2}` with `true` where the
 sub-elements are no further than the contact distance and `false` otherwise.
 """
 function contactmap(el_one::StructuralElementOrList,

--- a/test/structure/runtests.jl
+++ b/test/structure/runtests.jl
@@ -6,9 +6,20 @@ using Bio.Structure
 using TestFunctions.get_bio_fmt_specimens
 using Bio.Structure:
     fixlists!,
-    parsestrict,
-    parselenient,
-    parsevalue,
+    parseserial,
+    parseatomname,
+    parsealtloc,
+    parseresname,
+    parsechainid,
+    parseresnumber,
+    parseinscode,
+    parsecoordx,
+    parsecoordy,
+    parsecoordz,
+    parseoccupancy,
+    parsetempfac,
+    parseelement,
+    parsecharge,
     spacestring
 
 
@@ -562,39 +573,38 @@ end
 
 
 @testset "Parsing" begin
-    # Test parsevalue
-    line = "ATOM     40  CB  LEU A   5      22.088  45.547  29.675  1.00 22.23           C  "
-    @test parsevalue(line, 7, 11, Int) == 40
-    @test parsevalue(line, 31, 38, Float64) == 22.088
-    @test parsevalue(line, 13, 16, String) == " CB "
-    @test parsevalue(line, 22, 22, Char) == 'A'
-    @test_throws ErrorException parsevalue(line, 1, 4, Int)
-    @test_throws ErrorException parsevalue(line, 1, 4, Bool)
-    @test_throws ErrorException parsevalue(line, 79, 100, Int)
+    # Test parsing functions
+    line = "ATOM    591  C   GLY A  80      29.876  54.131  35.806  1.00 40.97           C1+"
+    @test parseserial(line) == 591
+    @test parseatomname(line) == " C  "
+    @test parsealtloc(line) == ' '
+    @test parseresname(line) == "GLY"
+    @test parsechainid(line) == 'A'
+    @test parseresnumber(line) == 80
+    @test parseinscode(line) == ' '
+    @test parsecoordx(line) == 29.876
+    @test parsecoordy(line) == 54.131
+    @test parsecoordz(line) == 35.806
+    @test parseoccupancy(line) == 1.0
+    @test parsetempfac(line) == 40.97
+    @test parseelement(line) == " C"
+    @test parsecharge(line) == "1+"
 
-
-    # Test parsestrict
-    line =   "ATOM    591  C   GLY A  80      29.876  54.131  35.806  1.00 40.97           C  "
-    line_a = "ATOM    591  C   GLY A  80              54.131  35.806  1.00 40.97           C  "
-    line_b = "ATOM    591  C   GLY A  80 "
-    @test parsestrict(line, 7, 11, Int, "could not read atom serial number", 10) == 591
-    @test parsestrict(line, 13, 16, String, "could not read atom name", 20) == " C  "
-    @test_throws PDBParseError parsestrict(line_a, 31, 38, Float64, "could not read x coordinate", 10)
-    @test_throws PDBParseError parsestrict(line_b, 31, 38, Float64, "could not read x coordinate", 10)
-    @test_throws PDBParseError parsestrict(line, 7, 11, Bool, "could not read atom serial number", 10)
-
-
-    # Test parselenient
-    line =   "ATOM     40  CB  LEU A   5      22.088  45.547  29.675  1.00 22.23           C  "
-    line_a = "ATOM     40  CB  LEU A   5      22.088  45.547  29.675  1.00 22.23              "
-    line_b = "ATOM     40  CB  LEU A   5      22.088  45.547  29.675  1.00 22.23  "
-    line_c = "ATOM     40  CB  LEU A   5      22.088  45.547  29.675       22.23           C  "
-    @test parselenient(line, 77, 78, String, "  ") == " C"
-    @test parselenient(line_a, 77, 78, String, "  ") == "  "
-    @test parselenient(line_b, 77, 78, String, "  ") == "  "
-    @test parselenient(line_b, 77, 78, String, " C") == " C"
-    @test parselenient(line_c, 55, 60, Float64, 1.0) == 1.0
-    @test parselenient(line, 77, 78, Bool, " N") == " N"
+    line_short = "ATOM    591  C"
+    @test_throws PDBParseError    parseserial("ATOM         C   GLY A  80      29.876  54.131  35.806  1.00 40.97           C1+")
+    @test_throws PDBParseError  parseatomname(line_short)
+    @test_throws PDBParseError    parsealtloc(line_short)
+    @test_throws PDBParseError   parseresname(line_short)
+    @test_throws PDBParseError   parsechainid(line_short)
+    @test_throws PDBParseError parseresnumber("ATOM    591  C   GLY A          29.876  54.131  35.806  1.00 40.97           C1+")
+    @test_throws PDBParseError   parseinscode(line_short)
+    @test_throws PDBParseError    parsecoordx("ATOM    591  C   GLY A  80      xxxxxx  54.131  35.806  1.00 40.97           C1+")
+    @test_throws PDBParseError    parsecoordy("ATOM    591  C   GLY A  80      29.876  xxxxxx  35.806  1.00 40.97           C1+")
+    @test_throws PDBParseError    parsecoordz("ATOM    591  C   GLY A  80      29.876  54.131  xxxxxx  1.00 40.97           C1+")
+    @test parseoccupancy(line_short) == 1.0
+    @test parsetempfac(line_short) == 0.0
+    @test parseelement(line_short) == "  "
+    @test parsecharge(line_short) == "  "
 
 
     # Test AtomRecord constructor


### PR DESCRIPTION
I've been sitting on this for a bit but forgot to push - it's a small change that speeds up PDB parsing by using individual functions for each entry type.

Parsing 1CRN goes from ~2.7 ms to ~1.4 ms, making Bio.jl the fastest PDB parser I have tested (see https://github.com/jgreener64/pdb-benchmarks).

I think it should go in before BioJulia v0.5 and the great repo switch.

Ready to review.