### PR TITLE
fix some Bio.Var tests

### DIFF
--- a/test/var/runtests.jl
+++ b/test/var/runtests.jl
@@ -6,6 +6,8 @@ using Bio: Seq, Var
 using TestFunctions
 using PairwiseListMatrices
 using IntervalTrees: IntervalValue
+import BufferedStreams: BufferedInputStream
+import YAML
 
 typealias PWM PairwiseListMatrix
 
@@ -311,7 +313,7 @@ end
     @test round(distance(Kimura80, m2)[2][1], 3) == 1
 
 end
-<<<<<<< HEAD
+=#
 
 @testset "VCF" begin
     metainfo = VCFMetaInfo()
@@ -677,6 +679,4 @@ end
     end
 end
 
-=======
-=#
 end # module TestVar


### PR DESCRIPTION
I didn't notice but large amounts of tests of Bio.Var are inside a block comment. This seems to be introduced in this commit: https://github.com/BioJulia/Bio.jl/commit/3ed91d20d140b2385aa5673bbf949700eb62fec8. Unfortunately, some tests didn't pass and I'm not sure how I should fix them. So, I narrowed the range of the comment and fixed a few test I could.

@Ward9250 Could you take care of that after change?