### PR TITLE
Promotion for DNA/RNA sequences

### DIFF
--- a/docs/src/man/seq/sequences/bioseq.md
+++ b/docs/src/man/seq/sequences/bioseq.md
@@ -25,7 +25,7 @@ The following table summarizes common sequence types that are defined in the
 
 Parameterized definition of the `BioSequence{A}` type is for the purpose of
 unifying the data structure and operations of any symbol type. In most cases,
-users don't have to care about it and can use type aliases listed above.
+users don't have to care about it and can use *type aliases* listed above.
 However, the alphabet type fixes the internal memory encoding and plays an
 important role when optimizing performance of a program
 (see [Using a more compact sequence representation](@ref) section for low-memory

--- a/src/seq/Seq.jl
+++ b/src/seq/Seq.jl
@@ -140,13 +140,15 @@ export
     FASTQ,
     TwoBit,
     AbifReader,
+
+    # Alphabets
     Alphabet,
     DNAAlphabet,
     RNAAlphabet,
     NucleicAcidAlphabets,
     AminoAcidAlphabet,
     CharAlphabet,
-    NucleicAcidAlphabet,
+
     ExactSearchQuery,
     ApproximateSearchQuery,
     approxsearch,

--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -80,8 +80,8 @@ alphabet(::Type{VoidAlphabet}) = nothing
 # ----------------------
 
 for alph in (DNAAlphabet, RNAAlphabet)
-    @eval function Base.promote_rule{A,B}(::Type{$alph{A}}, ::Type{$alph{B}})
-        return $alph{max(A,B)}
+    @eval function Base.promote_rule{A<:$alph,B<:$alph}(::Type{A}, ::Type{B})
+        return $alph{max(bitsof(A),bitsof(B))}
     end
 end
 

--- a/src/seq/alphabet.jl
+++ b/src/seq/alphabet.jl
@@ -42,7 +42,7 @@ Void alphabet (internal use only).
 """
 immutable VoidAlphabet <: Alphabet end
 
-typealias NucleicAcidAlphabet Union{DNAAlphabet,RNAAlphabet}
+typealias NucleicAcidAlphabets Union{DNAAlphabet,RNAAlphabet}
 
 """
 The number of bits to represent the alphabet.
@@ -76,6 +76,14 @@ alphabet(::Type{AminoAcidAlphabet}) = alphabet(AminoAcid)
 alphabet(::Type{CharAlphabet}) = typemin(Char):typemax(Char)
 alphabet(::Type{VoidAlphabet}) = nothing
 
+# Promotion of Alphabets
+# ----------------------
+
+for alph in (DNAAlphabet, RNAAlphabet)
+    @eval function Base.promote_rule{A,B}(::Type{$alph{A}}, ::Type{$alph{B}})
+        return $alph{max(A,B)}
+    end
+end
 
 # Encoders & Decoders
 # -------------------

--- a/src/seq/bioseq/conversion.jl
+++ b/src/seq/bioseq/conversion.jl
@@ -1,10 +1,22 @@
-# Convert
-# =======
+# Conversion & Promotion
+# ======================
 #
 # Conversion methods for biological sequences.
 #
 # This file is a part of BioJulia.
 # License is MIT: https://github.com/BioJulia/Bio.jl/blob/master/LICENSE.md
+
+# Promotion
+# ---------
+
+for alph in (DNAAlphabet, RNAAlphabet)
+    @eval function Base.promote_rule{A<:$alph,B<:$alph}(::Type{BioSequence{A}}, ::Type{BioSequence{B}})
+        return BioSequence{promote_rule(A,B)}
+    end
+end
+
+# Conversion
+# ----------
 
 # Conversion between sequences of different alphabet size.
 for A in [DNAAlphabet, RNAAlphabet]

--- a/src/seq/bioseq/operators.jl
+++ b/src/seq/bioseq/operators.jl
@@ -298,7 +298,7 @@ end
 # ---------
 
 """
-    majorityvote{A<:NucleicAcidAlphabet}(seqs::AbstractVector{BioSequence{A}})
+    majorityvote{A<:NucleicAcidAlphabets}(seqs::AbstractVector{BioSequence{A}})
 
 Construct a sequence that is a consensus of a vector of sequences.
 
@@ -326,7 +326,7 @@ julia> majorityvote(seqs)
 MTCGAAARATCG
 ```
 """
-function majorityvote{A<:NucleicAcidAlphabet}(seqs::AbstractVector{BioSequence{A}})
+function majorityvote{A<:NucleicAcidAlphabets}(seqs::AbstractVector{BioSequence{A}})
     mat = seqmatrix(UInt8, seqs, :site)
     nsites = size(mat, 2)
     nseqs = size(mat, 1)

--- a/test/seq/runtests.jl
+++ b/test/seq/runtests.jl
@@ -347,6 +347,17 @@ end
         EncodeError = Seq.EncodeError
         @test_throws EncodeError convert(BioSequence{DNAAlphabet{2}}, dna"AN")
         @test_throws EncodeError convert(BioSequence{RNAAlphabet{2}}, rna"AN")
+
+        # test promotion
+        a = BioSequence{DNAAlphabet{2}}("ATCG")
+        b = BioSequence{DNAAlphabet{4}}("ATCG")
+        c = BioSequence{RNAAlphabet{2}}("AUCG")
+        d = BioSequence{RNAAlphabet{4}}("AUCG")
+
+        @test typeof(promote(a, b)) == Tuple{BioSequence{DNAAlphabet{4}},BioSequence{DNAAlphabet{4}}}
+        @test typeof(promote(c, d)) == Tuple{BioSequence{RNAAlphabet{4}},BioSequence{RNAAlphabet{4}}}
+        @test typeof(promote(a, d)) == Tuple{BioSequence{DNAAlphabet{2}},BioSequence{RNAAlphabet{4}}}
+        @test typeof(promote(a, b, d)) == Tuple{BioSequence{DNAAlphabet{2}},BioSequence{DNAAlphabet{4}},BioSequence{RNAAlphabet{4}}}
     end
 
     @testset "Conversion between RNA and DNA" begin


### PR DESCRIPTION
This PR will add promotion to biological sequences in order to allow completion of #436.

Essentially the rule will be if you have DNA or RNA sequences and want to promote them to the same type, they will be promoted to the alphabet that is capable of representing all the possible elements, so `promote_rule(DNAAlphabet{2}, DNAAlphabet{4})` will return `DNAAlphabet{4}`, as `DNAAlphabet{4}` is the one that is capable of representing all elements of `DNAAlphabet{2} and DNAAlphabet{4}`.