### PR TITLE
add isprimary for SAM.Record and BAM.Record

### DIFF
--- a/docs/src/man/reading.md
+++ b/docs/src/man/reading.md
@@ -408,6 +408,7 @@ Bio.Align.SAM.keyvalues
 Bio.Align.SAM.Record
 Bio.Align.SAM.flag
 Bio.Align.SAM.ismapped
+Bio.Align.SAM.isprimary
 Bio.Align.SAM.refname
 Bio.Align.SAM.position
 Bio.Align.SAM.rightposition
@@ -467,6 +468,7 @@ Bio.Align.BAM.Writer
 Bio.Align.BAM.Record
 Bio.Align.BAM.flag
 Bio.Align.BAM.ismapped
+Bio.Align.BAM.isprimary
 Bio.Align.BAM.refid
 Bio.Align.BAM.refname
 Bio.Align.BAM.position

--- a/src/align/bam/record.jl
+++ b/src/align/bam/record.jl
@@ -112,8 +112,19 @@ end
 
 Test if `record` is mapped.
 """
-function ismapped(record::Record)
+function ismapped(record::Record)::Bool
     return flag(record) & SAM.FLAG_UNMAP == 0
+end
+
+"""
+    isprimary(record::Record)::Bool
+
+Test if `record` is a primary line of the read.
+
+This is equivalent to `flag(record) & 0x900 == 0`.
+"""
+function isprimary(record::Record)::Bool
+    return flag(record) & 0x900 == 0
 end
 
 """

--- a/src/align/sam/record.jl
+++ b/src/align/sam/record.jl
@@ -154,6 +154,17 @@ function ismapped(record::Record)::Bool
 end
 
 """
+    isprimary(record::Record)::Bool
+
+Test if `record` is a primary line of the read.
+
+This is equivalent to `flag(record) & 0x900 == 0`.
+"""
+function isprimary(record::Record)::Bool
+    return flag(record) & 0x900 == 0
+end
+
+"""
     refname(record::Record)::String
 
 Get the reference sequence name of `record`.

--- a/test/align/runtests.jl
+++ b/test/align/runtests.jl
@@ -1060,6 +1060,7 @@ end
             @test isfilled(record)
             @test ismatch(r"^Bio.Align.SAM.Record:\n", repr(record))
             @test SAM.ismapped(record)
+            @test SAM.isprimary(record)
             @test SAM.hastempname(record)
             @test SAM.tempname(record) == "r001"
             @test SAM.hasflag(record)
@@ -1219,6 +1220,7 @@ end
             record = BAM.Record()
             read!(reader, record)
             @test BAM.ismapped(record)
+            @test BAM.isprimary(record)
             @test BAM.refname(record) == "CHROMOSOME_I"
             @test BAM.refid(record) === 1
             @test BAM.hasnextrefid(record)


### PR DESCRIPTION
According to the SAM specs:
> For each read/contig in a SAM file, it is required that one and only one line associated with the
read satisfies ‘FLAG & 0x900 == 0’. This line is called the primary line of the read.

I found this is sometimes useful.