### PR TITLE
implement a faster and simpler eachkmer

### DIFF
--- a/src/seq/composition.jl
+++ b/src/seq/composition.jl
@@ -45,12 +45,12 @@ function Composition(seq::AminoAcidSequence)
     return Composition{AminoAcid}(counts)
 end
 
-function Composition{T,k}(iter::EachKmerIterator{T,k})
-    counts = zeros(Int, 4^k)
+function Composition{T<:Kmer}(iter::EachKmerIterator{T})
+    counts = zeros(Int, 4^kmersize(T))
     for (_, x) in iter
         counts[convert(UInt64, x) + 1] += 1
     end
-    return Composition{Kmer{T,k}}(counts)
+    return Composition{T}(counts)
 end
 
 """

--- a/src/seq/kmer.jl
+++ b/src/seq/kmer.jl
@@ -121,7 +121,9 @@ alphabet{k}(::Type{RNAKmer{k}}) = (RNA_A, RNA_C, RNA_G, RNA_U)
 
 Base.hash(x::Kmer, h::UInt) = hash(UInt64(x), h)
 
-Base.length{T,K}(x::Kmer{T, K}) = K
+kmersize{T,k}(::Type{Kmer{T,k}}) = k
+kmersize(kmer::Kmer) = kmersize(typeof(kmer))
+Base.length{T,K}(x::Kmer{T, K}) = kmersize(x)
 Base.eltype{T,k}(::Type{Kmer{T,k}}) = T
 
 @inline function inbounds_getindex{T,K}(x::Kmer{T,K}, i::Integer)


### PR DESCRIPTION
On my machine, `composition` is now ~20-30% faster for short kmers (e.g. 4-8).

```
~/.j/v/B/benchmarks (faster-eachkmer|…) $ julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.5.1 (2017-03-05 13:25 UTC)
 _/ |\__'_|_|_|\__'_|  |
|__/                   |  x86_64-apple-darwin16.4.0

julia> using BenchmarkTools

julia> using Bio.Seq
INFO: Recompiling stale cache file /Users/kenta/.julia/lib/v0.5/Bio.ji for module Bio.
INFO: compiling FASTA
INFO: compiling FASTQ
INFO: compiling old FASTA
INFO: compiling BED
INFO: compiling GFF3
INFO: compiling SAM
INFO: compiling VCF
WARNING: Method definition require(Symbol) in module Base at loading.jl:345 overwritten in module Main at /Users/kenta/.julia/v0.5/Requires/src/require.jl:12.

julia> srand(1234); seq = randdnaseq(10_000);

julia> @benchmark composition(each(DNAKmer{4}, seq))
BenchmarkTools.Trial:
  memory estimate:  2.20 KiB
  allocs estimate:  5
  --------------
  minimum time:     55.265 μs (0.00% GC)
  median time:      56.282 μs (0.00% GC)
  mean time:        59.166 μs (0.40% GC)
  maximum time:     2.444 ms (97.03% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{8}, seq))
BenchmarkTools.Trial:
  memory estimate:  512.16 KiB
  allocs estimate:  6
  --------------
  minimum time:     122.389 μs (0.00% GC)
  median time:      273.634 μs (0.00% GC)
  mean time:        277.880 μs (13.36% GC)
  maximum time:     3.291 ms (79.79% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{12}, seq))
BenchmarkTools.Trial:
  memory estimate:  128.00 MiB
  allocs estimate:  6
  --------------
  minimum time:     74.796 ms (15.56% GC)
  median time:      76.573 ms (15.36% GC)
  mean time:        80.761 ms (19.41% GC)
  maximum time:     156.987 ms (58.30% GC)
  --------------
  samples:          62
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{8}, seq, 3))
BenchmarkTools.Trial:
  memory estimate:  512.16 KiB
  allocs estimate:  6
  --------------
  minimum time:     82.236 μs (0.00% GC)
  median time:      256.368 μs (0.00% GC)
  mean time:        269.561 μs (14.29% GC)
  maximum time:     3.423 ms (81.44% GC)
  --------------
  samples:          10000
  evals/sample:     1

```

```
~/.j/v/B/benchmarks (master|…) $ julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.5.1 (2017-03-05 13:25 UTC)
 _/ |\__'_|_|_|\__'_|  |
|__/                   |  x86_64-apple-darwin16.4.0

julia> using BenchmarkTools

julia> using Bio.Seq
WARNING: Method definition require(Symbol) in module Base at loading.jl:345 overwritten in module Main at /Users/kenta/.julia/v0.5/Requires/src/require.jl:12.

julia> srand(1234); seq = randdnaseq(10_000);

julia> @benchmark composition(each(DNAKmer{4}, seq))
BenchmarkTools.Trial:
  memory estimate:  2.20 KiB
  allocs estimate:  5
  --------------
  minimum time:     67.114 μs (0.00% GC)
  median time:      68.988 μs (0.00% GC)
  mean time:        72.054 μs (0.33% GC)
  maximum time:     2.428 ms (96.46% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{8}, seq))
BenchmarkTools.Trial:
  memory estimate:  512.16 KiB
  allocs estimate:  6
  --------------
  minimum time:     159.216 μs (0.00% GC)
  median time:      349.833 μs (0.00% GC)
  mean time:        343.539 μs (12.50% GC)
  maximum time:     3.673 ms (80.46% GC)
  --------------
  samples:          10000
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{12}, seq))
BenchmarkTools.Trial:
  memory estimate:  128.00 MiB
  allocs estimate:  6
  --------------
  minimum time:     74.641 ms (15.39% GC)
  median time:      76.195 ms (15.36% GC)
  mean time:        80.647 ms (19.44% GC)
  maximum time:     158.713 ms (57.95% GC)
  --------------
  samples:          62
  evals/sample:     1

julia> @benchmark composition(each(DNAKmer{8}, seq, 3))
BenchmarkTools.Trial:
  memory estimate:  512.16 KiB
  allocs estimate:  6
  --------------
  minimum time:     113.664 μs (0.00% GC)
  median time:      311.359 μs (0.00% GC)
  mean time:        300.800 μs (14.07% GC)
  maximum time:     3.596 ms (82.28% GC)
  --------------
  samples:          10000
  evals/sample:     1

```