### PR TITLE
Remove PDB update test that may fail

### DIFF
--- a/src/structure/pdb.jl
+++ b/src/structure/pdb.jl
@@ -94,15 +94,18 @@ function pdbstatuslist(url::AbstractString)
     tempfilepath = tempname()
     try
         download(url, tempfilepath)
-        open(tempfilepath) do input
-            for line in eachline(input)
-                # The first 4 characters in the line is the PDB ID
-                pdbid = uppercase(line[1:4])
-                # Check PDB ID is 4 characters long and only consits of alphanumeric characters
-                if !ismatch(r"^[a-zA-Z0-9]{4}$", pdbid)
-                    throw(ArgumentError("Not a valid PDB ID: \"$pdbid\""))
+        # Some operating systems don't create a file if the download is empty
+        if isfile(tempfilepath)
+            open(tempfilepath) do input
+                for line in eachline(input)
+                    # The first 4 characters in the line is the PDB ID
+                    pdbid = uppercase(line[1:4])
+                    # Check PDB ID is 4 characters long and only consits of alphanumeric characters
+                    if !ismatch(r"^[a-zA-Z0-9]{4}$", pdbid)
+                        throw(ArgumentError("Not a valid PDB ID: \"$pdbid\""))
+                    end
+                    push!(statuslist,pdbid)
                 end
-                push!(statuslist,pdbid)
             end
         end
     finally

--- a/test/structure/runtests.jl
+++ b/test/structure/runtests.jl
@@ -36,7 +36,6 @@ end
     #Invalid URL
     @test_throws ErrorException pdbstatuslist("ftp://ftp.wwpdb.org/pub/pdb/data/status/latest/dummy.pdb")
     addedlist, modifiedlist, obsoletelist = pdbrecentchanges()
-    @test length(addedlist) > 0 && length(modifiedlist) > 0 && length(obsoletelist) > 0
     @test length(pdbobsoletelist()) > 3600
 
     pdb_dir = joinpath(tempdir(),"PDB")


### PR DESCRIPTION
This test of the PDB can actually fail if no entries were obsoleted recently.